### PR TITLE
Addressing issue #70: Version of gps-camera and gps-entity-place using Spherical Mercator p…

### DIFF
--- a/aframe/build/aframe-ar-nft.js
+++ b/aframe/build/aframe-ar-nft.js
@@ -4435,6 +4435,563 @@ function formatDistance(distance) {
 
     return distance + ' meters';
 };
+/** gps-projected-camera
+ *
+ * based on the original gps-camera, modified by nickw 02/04/20
+ *
+ * Rather than keeping track of position by calculating the distance of
+ * entities or the current location to the original location, this version
+ * makes use of the "Google" Spherical Mercactor projection, aka epsg:3857.
+ *
+ * The original position (lat/lon) is projected into Spherical Mercator and
+ * stored.
+ *
+ * Then, when we receive a new position (lat/lon), this new position is
+ * projected into Spherical Mercator and then its world position calculated
+ * by comparing against the original position.
+ *
+ * The same is also the case for 'entity-places'; when these are added, their
+ * Spherical Mercator coords are calculated (see gps-projected-entity-place).
+ *
+ * Spherical Mercator units are close to, but not exactly, metres, and are
+ * heavily distorted near the poles. Nonetheless they are a good approximation
+ * for many areas of the world and appear not to cause unacceptable distortions
+ * when used as the units for AR apps.
+ */
+
+AFRAME.registerComponent('gps-projected-camera', {
+    _watchPositionId: null,
+    originCoordsProjected: null, // original coords now in Spherical Mercator
+    currentCoords: null,
+    lookControls: null,
+    heading: null,
+    schema: {
+        simulateLatitude: {
+            type: 'number',
+            default: 0,
+        },
+        simulateLongitude: {
+            type: 'number',
+            default: 0,
+        },
+        simulateAltitude: {
+            type: 'number',
+            default: 0,
+        },
+        positionMinAccuracy: {
+            type: 'int',
+            default: 100,
+        },
+        alert: {
+            type: 'boolean',
+            default: false,
+        },
+        minDistance: {
+            type: 'int',
+            default: 0,
+        }
+    },
+    update: function() {
+        if (this.data.simulateLatitude !== 0 && this.data.simulateLongitude !== 0) {
+            localPosition = Object.assign({}, this.currentCoords || {});
+            localPosition.longitude = this.data.simulateLongitude;
+            localPosition.latitude = this.data.simulateLatitude;
+            localPosition.altitude = this.data.simulateAltitude;
+            this.currentCoords = localPosition;
+
+            // re-trigger initialization for new origin
+            this.originCoordsProjected = null;
+            this._updatePosition();
+        }
+    },
+    init: function () {
+        if (!this.el.components['look-controls']) {
+            return;
+        }
+
+        this.loader = document.createElement('DIV');
+        this.loader.classList.add('arjs-loader');
+        document.body.appendChild(this.loader);
+
+        window.addEventListener('gps-entity-place-added', function () {
+            // if places are added after camera initialization is finished
+            if (this.originCoordsProjected) {
+                window.dispatchEvent(new CustomEvent('gps-camera-origin-coord-set'));
+            }
+            if (this.loader && this.loader.parentElement) {
+                document.body.removeChild(this.loader)
+            }
+        }.bind(this));
+
+        this.lookControls = this.el.components['look-controls'];
+
+        // listen to deviceorientation event
+        var eventName = this._getDeviceOrientationEventName();
+        this._onDeviceOrientation = this._onDeviceOrientation.bind(this);
+
+        // if Safari
+        if (!!navigator.userAgent.match(/Version\/[\d.]+.*Safari/)) {
+            // iOS 13+
+            if (typeof DeviceOrientationEvent.requestPermission === 'function') {
+                var handler = function () {
+                    console.log('Requesting device orientation permissions...')
+                    DeviceOrientationEvent.requestPermission();
+                    document.removeEventListener('touchend', handler);
+                };
+
+                document.addEventListener('touchend', function () { handler() }, false);
+
+                alert('After camera permission prompt, please tap the screen to activate geolocation.');
+            } else {
+                var timeout = setTimeout(function () {
+                    alert('Please enable device orientation in Settings > Safari > Motion & Orientation Access.')
+                }, 750);
+                window.addEventListener(eventName, function () {
+                    clearTimeout(timeout);
+                });
+            }
+        }
+
+        window.addEventListener(eventName, this._onDeviceOrientation, false);
+
+        this._watchPositionId = this._initWatchGPS(function (position) {
+            if (this.data.simulateLatitude !== 0 && this.data.simulateLongitude !== 0) {
+                localPosition = Object.assign({}, position.coords);
+                localPosition.longitude = this.data.simulateLongitude;
+                localPosition.latitude = this.data.simulateLatitude;
+                localPosition.altitude = this.data.simulateAltitude;
+                this.currentCoords = localPosition;
+            }
+            else {
+                this.currentCoords = position.coords;
+            }
+
+            this._updatePosition();
+        }.bind(this));
+    },
+
+    tick: function () {
+        if (this.heading === null) {
+            return;
+        }
+        this._updateRotation();
+    },
+
+    remove: function () {
+        if (this._watchPositionId) {
+            navigator.geolocation.clearWatch(this._watchPositionId);
+        }
+        this._watchPositionId = null;
+
+        var eventName = this._getDeviceOrientationEventName();
+        window.removeEventListener(eventName, this._onDeviceOrientation, false);
+    },
+
+    /**
+     * Get device orientation event name, depends on browser implementation.
+     * @returns {string} event name
+     */
+    _getDeviceOrientationEventName: function () {
+        if ('ondeviceorientationabsolute' in window) {
+            var eventName = 'deviceorientationabsolute'
+        } else if ('ondeviceorientation' in window) {
+            var eventName = 'deviceorientation'
+        } else {
+            var eventName = ''
+            console.error('Compass not supported')
+        }
+
+        return eventName
+    },
+
+    /**
+     * Get current user position.
+     *
+     * @param {function} onSuccess
+     * @param {function} onError
+     * @returns {Promise}
+     */
+    _initWatchGPS: function (onSuccess, onError) {
+        if (!onError) {
+            onError = function (err) {
+                console.warn('ERROR(' + err.code + '): ' + err.message)
+
+                if (err.code === 1) {
+                    // User denied GeoLocation, let their know that
+                    alert('Please activate Geolocation and refresh the page. If it is already active, please check permissions for this website.');
+                    return;
+                }
+
+                if (err.code === 3) {
+                    console.error('Cannot retrieve GPS position. Signal is absent.');
+                    return;
+                }
+            };
+        }
+
+        if ('geolocation' in navigator === false) {
+            onError({ code: 0, message: 'Geolocation is not supported by your browser' });
+            return Promise.resolve();
+        }
+
+        // https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/watchPosition
+        return navigator.geolocation.watchPosition(onSuccess, onError, {
+            enableHighAccuracy: true,
+            maximumAge: 0,
+            timeout: 27000,
+        });
+    },
+
+    /**
+     * Update user position.
+     *
+     * @returns {void}
+     */
+    _updatePosition: function () {
+        // don't update if accuracy is not good enough
+        if (this.currentCoords.accuracy > this.data.positionMinAccuracy) {
+            if (this.data.alert && !document.getElementById('alert-popup')) {
+                var popup = document.createElement('div');
+                popup.innerHTML = 'GPS signal is very poor. Try move outdoor or to an area with a better signal.'
+                popup.setAttribute('id', 'alert-popup');
+                document.body.appendChild(popup);
+            }
+            return;
+        }
+
+        var alertPopup = document.getElementById('alert-popup');
+        if (this.currentCoords.accuracy <= this.data.positionMinAccuracy && alertPopup) {
+            document.body.removeChild(alertPopup);
+        }
+
+        if (!this.originCoordsProjected) {
+            // first camera initialization
+            // Now store originCoordsProjected as PROJECTED original lat/lon, so that
+            // we can set the world origin to the original position in "metres"
+            this.originCoordsProjected = this._project(this.currentCoords.latitude, this.currentCoords.longitude);
+            this._setPosition();
+
+            var loader = document.querySelector('.arjs-loader');
+            if (loader) {
+                loader.remove();
+            }
+            window.dispatchEvent(new CustomEvent('gps-camera-origin-coord-set'));
+        } else {
+            this._setPosition();
+        }
+    },
+    /**
+     * Set the current position (in world coords, based on Spherical Mercator)
+     *
+     * @returns {void}
+     */
+    _setPosition: function () {
+        var position = this.el.getAttribute('position');
+
+        var worldCoords = this.latLonToWorld(this.currentCoords.latitude, this.currentCoords.longitude);
+
+        position.x = worldCoords[0];
+        position.z = worldCoords[1]; 
+
+        // update position
+        this.el.setAttribute('position', position);
+
+        // add the sphmerc position to the event (for testing only)
+        window.dispatchEvent(new CustomEvent('gps-camera-update-position', { detail: { position: this.currentCoords, origin: this.originCoordsProjected } }));
+    },
+    /**
+     * Returns distance in meters between camera and destination input.
+     *
+     * Assume we are using a metre-based projection. Not all 'metre-based'
+     * projections give exact metres, e.g. Spherical Mercator, but it appears 
+     * close enough to be used for AR at least in middle temperate 
+     * latitudes (40 - 55). It is heavily distorted near the poles, however.
+     *
+     * @param {Position} dest
+     * @param {Boolean} isPlace
+     *
+     * @returns {number} distance | Number.MAX_SAFE_INTEGER
+     */
+    computeDistanceMeters: function (dest, isPlace) {
+        var src = this.el.getAttribute("position");
+        var dx = dest.x - src.x;
+        var dz = dest.z - src.z;
+        var distance = Math.sqrt(dx * dx + dz * dz);
+
+        // if function has been called for a place, and if it's too near and a min distance has been set,
+        // return max distance possible - to be handled by the  method caller
+        if (isPlace && this.data.minDistance && this.data.minDistance > 0 && distance < this.data.minDistance) {
+            return Number.MAX_SAFE_INTEGER;
+        }
+
+        return distance;
+    },
+    /**
+     * Converts latitude/longitude to OpenGL world coordinates. 
+     *
+     * First projects lat/lon to absolute Spherical Mercator and then 
+     * calculates the world coordinates by comparing the Spherical Mercator
+     * coordinates with the Spherical Mercator coordinates of the origin point.
+     *
+     * @param {Number} lat 
+     * @param {Number} lon 
+     *
+     * @returns {array} world coordinates 
+     */
+    latLonToWorld: function(lat, lon) {
+        var projected = this._project (lat, lon);
+        // Sign of z needs to be reversed compared to projected coordinates
+        return [ projected[0] - this.originCoordsProjected[0], -(projected[1] - this.originCoordsProjected[1]) ];
+    },
+    /**
+     * Converts latitude/longitude to Spherical Mercator coordinates. 
+     * Algorithm is used in several OpenStreetMap-related applications.
+     *
+     * @param {Number} lat 
+     * @param {Number} lon 
+     *
+     * @returns {array} Spherical Mercator coordinates 
+     */
+    _project: function (lat, lon) {
+        const HALF_EARTH = 20037508.34;
+
+        // Convert the supplied coords to Spherical Mercator (EPSG:3857), also
+        // known as 'Google Projection', using the algorithm used extensively 
+        // in various OpenStreetMap software.
+        var y = Math.log(Math.tan((90 + lat) * Math.PI / 360.0)) / (Math.PI / 180.0);
+        return [ (lon / 180.0) * HALF_EARTH, y * HALF_EARTH / 180.0 ];
+    },
+    /**
+     * Converts Spherical Mercator coordinates to latitude/longitude.
+     * Algorithm is used in several OpenStreetMap-related applications.
+     *
+     * @param {Number} spherical mercator easting 
+     * @param {Number} spherical mercator northing 
+     *
+     * @returns {object} lon/lat
+     */
+    _unproject: function (e, n) {
+        const HALF_EARTH = 20037508.34;
+        var yp = (n / HALF_EARTH) * 180.0;
+        return { 
+            longitude: (e / HALF_EARTH) * 180.0,
+            latitude: 180.0 / Math.PI * (2 * Math.atan(Math.exp(yp * Math.PI / 180.0)) - Math.PI / 2)
+        };
+    },
+    /**
+     * Compute compass heading.
+     *
+     * @param {number} alpha
+     * @param {number} beta
+     * @param {number} gamma
+     *
+     * @returns {number} compass heading
+     */
+    _computeCompassHeading: function (alpha, beta, gamma) {
+
+        // Convert degrees to radians
+        var alphaRad = alpha * (Math.PI / 180);
+        var betaRad = beta * (Math.PI / 180);
+        var gammaRad = gamma * (Math.PI / 180);
+
+        // Calculate equation components
+        var cA = Math.cos(alphaRad);
+        var sA = Math.sin(alphaRad);
+        var sB = Math.sin(betaRad);
+        var cG = Math.cos(gammaRad);
+        var sG = Math.sin(gammaRad);
+
+        // Calculate A, B, C rotation components
+        var rA = - cA * sG - sA * sB * cG;
+        var rB = - sA * sG + cA * sB * cG;
+
+        // Calculate compass heading
+        var compassHeading = Math.atan(rA / rB);
+
+        // Convert from half unit circle to whole unit circle
+        if (rB < 0) {
+            compassHeading += Math.PI;
+        } else if (rA < 0) {
+            compassHeading += 2 * Math.PI;
+        }
+
+        // Convert radians to degrees
+        compassHeading *= 180 / Math.PI;
+
+        return compassHeading;
+    },
+
+    /**
+     * Handler for device orientation event.
+     *
+     * @param {Event} event
+     * @returns {void}
+     */
+    _onDeviceOrientation: function (event) {
+        if (event.webkitCompassHeading !== undefined) {
+            if (event.webkitCompassAccuracy < 50) {
+                this.heading = event.webkitCompassHeading;
+            } else {
+                console.warn('webkitCompassAccuracy is event.webkitCompassAccuracy');
+            }
+        } else if (event.alpha !== null) {
+            if (event.absolute === true || event.absolute === undefined) {
+                this.heading = this._computeCompassHeading(event.alpha, event.beta, event.gamma);
+            } else {
+                console.warn('event.absolute === false');
+            }
+        } else {
+            console.warn('event.alpha === null');
+        }
+    },
+
+    /**
+     * Update user rotation data.
+     *
+     * @returns {void}
+     */
+    _updateRotation: function () {
+        var heading = 360 - this.heading;
+        var cameraRotation = this.el.getAttribute('rotation').y;
+        var yawRotation = THREE.Math.radToDeg(this.lookControls.yawObject.rotation.y);
+        var offset = (heading - (cameraRotation - yawRotation)) % 360;
+        this.lookControls.yawObject.rotation.y = THREE.Math.degToRad(offset);
+    },
+});
+/** gps-projected-entity-place
+ *
+ * based on the original gps-entity-place, modified by nickw 02/04/20
+ *
+ * Rather than keeping track of position by calculating the distance of
+ * entities or the current location to the original location, this version
+ * makes use of the "Google" Spherical Mercactor projection, aka epsg:3857.
+ *
+ * The original location on startup (lat/lon) is projected into Spherical 
+ * Mercator and stored.
+ *
+ * When 'entity-places' are added, their Spherical Mercator coords are 
+ * calculated and converted into world coordinates, relative to the original
+ * position, using the Spherical Mercator projection calculation in
+ * gps-projected-camera.
+ *
+ * Spherical Mercator units are close to, but not exactly, metres, and are
+ * heavily distorted near the poles. Nonetheless they are a good approximation
+ * for many areas of the world and appear not to cause unacceptable distortions
+ * when used as the units for AR apps.
+ */
+AFRAME.registerComponent('gps-projected-entity-place', {
+    _cameraGps: null,
+    schema: {
+        longitude: {
+            type: 'number',
+            default: 0,
+        },
+        latitude: {
+            type: 'number',
+            default: 0,
+        },
+        elevation: {
+            type: 'number',
+            default: 0
+        }
+    },
+    remove: function() {
+        // cleaning listeners when the entity is removed from the DOM
+        window.removeEventListener('gps-camera-update-position', this.updatePositionListener);
+    },
+    init: function() {
+        // Used now to get the GPS camera when it's been setup
+        this.coordSetListener = () => {
+            if (!this._cameraGps) {
+                var camera = document.querySelector('[gps-projected-camera]');
+                if (!camera.components['gps-projected-camera']) {
+                    console.error('gps-projected-camera not initialized')
+                    return;
+                }
+                this._cameraGps = camera.components['gps-projected-camera'];
+                this._updatePosition();
+            }
+        };
+        
+
+
+        // update position needs to worry about distance but nothing else?
+        this.updatePositionListener = (ev) => {
+            if (!this.data || !this._cameraGps) {
+                return;
+            }
+
+            var dstCoords = this.getAttribute('position');
+
+            // it's actually a 'distance place', but we don't call it with last param, because we want to retrieve distance even if it's < minDistance property
+            // _computeDistanceMeters is now going to use the projected
+            var distanceForMsg = this._cameraGps.computeDistanceMeters(dstCoords);
+
+            this.el.setAttribute('distance', distanceForMsg);
+            this.el.setAttribute('distanceMsg', formatDistance(distanceForMsg));
+
+            this.el.dispatchEvent(new CustomEvent('gps-entity-place-update-positon', { detail: { distance: distanceForMsg } }));
+
+            var actualDistance = this._cameraGps.computeDistanceMeters(dstCoords, true);
+
+            if (actualDistance === Number.MAX_SAFE_INTEGER) {
+                this.hideForMinDistance(this.el, true);
+            } else {
+                this.hideForMinDistance(this.el, false);
+            }
+        };
+
+        // Retain as this event is fired when the GPS camera is set up
+        window.addEventListener('gps-camera-origin-coord-set', this.coordSetListener);
+        window.addEventListener('gps-camera-update-position', this.updatePositionListener);
+
+        this._positionXDebug = 0;
+
+        window.dispatchEvent(new CustomEvent('gps-entity-place-added', { detail: { component: this.el } }));
+    },
+    /**
+     * Hide entity according to minDistance property
+     * @returns {void}
+     */
+    hideForMinDistance: function(el, hideEntity) {
+        if (hideEntity) {
+            el.setAttribute('visible', 'false');
+        } else {
+            el.setAttribute('visible', 'true');
+        }
+    },
+    /**
+     * Update place position
+     * @returns {void}
+     */
+
+    // set position to world coords using the lat/lon 
+    _updatePosition: function() {
+        var pos = this._cameraGps.latLonToWorld(this.data.latitude, this.data.longitude);
+        // update element's position in 3D world
+        //this.el.setAttribute('position', position);
+        this.el.setAttribute('position', {
+            x: pos[0],
+            y: this.data.elevation,
+            z: pos[1]
+        }); 
+    },
+});
+
+/**
+ * Format distances string
+ *
+ * @param {String} distance
+ */
+function formatDistance(distance) {
+    distance = distance.toFixed(0);
+
+    if (distance >= 1000) {
+        return (distance / 1000) + ' kilometers';
+    }
+
+    return distance + ' meters';
+};
 AFRAME.registerSystem('arjs', {
     schema: {
         trackingMethod: {

--- a/aframe/build/aframe-ar.js
+++ b/aframe/build/aframe-ar.js
@@ -5787,6 +5787,563 @@ function formatDistance(distance) {
 
     return distance + ' meters';
 };
+/** gps-projected-camera
+ *
+ * based on the original gps-camera, modified by nickw 02/04/20
+ *
+ * Rather than keeping track of position by calculating the distance of
+ * entities or the current location to the original location, this version
+ * makes use of the "Google" Spherical Mercactor projection, aka epsg:3857.
+ *
+ * The original position (lat/lon) is projected into Spherical Mercator and
+ * stored.
+ *
+ * Then, when we receive a new position (lat/lon), this new position is
+ * projected into Spherical Mercator and then its world position calculated
+ * by comparing against the original position.
+ *
+ * The same is also the case for 'entity-places'; when these are added, their
+ * Spherical Mercator coords are calculated (see gps-projected-entity-place).
+ *
+ * Spherical Mercator units are close to, but not exactly, metres, and are
+ * heavily distorted near the poles. Nonetheless they are a good approximation
+ * for many areas of the world and appear not to cause unacceptable distortions
+ * when used as the units for AR apps.
+ */
+
+AFRAME.registerComponent('gps-projected-camera', {
+    _watchPositionId: null,
+    originCoordsProjected: null, // original coords now in Spherical Mercator
+    currentCoords: null,
+    lookControls: null,
+    heading: null,
+    schema: {
+        simulateLatitude: {
+            type: 'number',
+            default: 0,
+        },
+        simulateLongitude: {
+            type: 'number',
+            default: 0,
+        },
+        simulateAltitude: {
+            type: 'number',
+            default: 0,
+        },
+        positionMinAccuracy: {
+            type: 'int',
+            default: 100,
+        },
+        alert: {
+            type: 'boolean',
+            default: false,
+        },
+        minDistance: {
+            type: 'int',
+            default: 0,
+        }
+    },
+    update: function() {
+        if (this.data.simulateLatitude !== 0 && this.data.simulateLongitude !== 0) {
+            localPosition = Object.assign({}, this.currentCoords || {});
+            localPosition.longitude = this.data.simulateLongitude;
+            localPosition.latitude = this.data.simulateLatitude;
+            localPosition.altitude = this.data.simulateAltitude;
+            this.currentCoords = localPosition;
+
+            // re-trigger initialization for new origin
+            this.originCoordsProjected = null;
+            this._updatePosition();
+        }
+    },
+    init: function () {
+        if (!this.el.components['look-controls']) {
+            return;
+        }
+
+        this.loader = document.createElement('DIV');
+        this.loader.classList.add('arjs-loader');
+        document.body.appendChild(this.loader);
+
+        window.addEventListener('gps-entity-place-added', function () {
+            // if places are added after camera initialization is finished
+            if (this.originCoordsProjected) {
+                window.dispatchEvent(new CustomEvent('gps-camera-origin-coord-set'));
+            }
+            if (this.loader && this.loader.parentElement) {
+                document.body.removeChild(this.loader)
+            }
+        }.bind(this));
+
+        this.lookControls = this.el.components['look-controls'];
+
+        // listen to deviceorientation event
+        var eventName = this._getDeviceOrientationEventName();
+        this._onDeviceOrientation = this._onDeviceOrientation.bind(this);
+
+        // if Safari
+        if (!!navigator.userAgent.match(/Version\/[\d.]+.*Safari/)) {
+            // iOS 13+
+            if (typeof DeviceOrientationEvent.requestPermission === 'function') {
+                var handler = function () {
+                    console.log('Requesting device orientation permissions...')
+                    DeviceOrientationEvent.requestPermission();
+                    document.removeEventListener('touchend', handler);
+                };
+
+                document.addEventListener('touchend', function () { handler() }, false);
+
+                alert('After camera permission prompt, please tap the screen to activate geolocation.');
+            } else {
+                var timeout = setTimeout(function () {
+                    alert('Please enable device orientation in Settings > Safari > Motion & Orientation Access.')
+                }, 750);
+                window.addEventListener(eventName, function () {
+                    clearTimeout(timeout);
+                });
+            }
+        }
+
+        window.addEventListener(eventName, this._onDeviceOrientation, false);
+
+        this._watchPositionId = this._initWatchGPS(function (position) {
+            if (this.data.simulateLatitude !== 0 && this.data.simulateLongitude !== 0) {
+                localPosition = Object.assign({}, position.coords);
+                localPosition.longitude = this.data.simulateLongitude;
+                localPosition.latitude = this.data.simulateLatitude;
+                localPosition.altitude = this.data.simulateAltitude;
+                this.currentCoords = localPosition;
+            }
+            else {
+                this.currentCoords = position.coords;
+            }
+
+            this._updatePosition();
+        }.bind(this));
+    },
+
+    tick: function () {
+        if (this.heading === null) {
+            return;
+        }
+        this._updateRotation();
+    },
+
+    remove: function () {
+        if (this._watchPositionId) {
+            navigator.geolocation.clearWatch(this._watchPositionId);
+        }
+        this._watchPositionId = null;
+
+        var eventName = this._getDeviceOrientationEventName();
+        window.removeEventListener(eventName, this._onDeviceOrientation, false);
+    },
+
+    /**
+     * Get device orientation event name, depends on browser implementation.
+     * @returns {string} event name
+     */
+    _getDeviceOrientationEventName: function () {
+        if ('ondeviceorientationabsolute' in window) {
+            var eventName = 'deviceorientationabsolute'
+        } else if ('ondeviceorientation' in window) {
+            var eventName = 'deviceorientation'
+        } else {
+            var eventName = ''
+            console.error('Compass not supported')
+        }
+
+        return eventName
+    },
+
+    /**
+     * Get current user position.
+     *
+     * @param {function} onSuccess
+     * @param {function} onError
+     * @returns {Promise}
+     */
+    _initWatchGPS: function (onSuccess, onError) {
+        if (!onError) {
+            onError = function (err) {
+                console.warn('ERROR(' + err.code + '): ' + err.message)
+
+                if (err.code === 1) {
+                    // User denied GeoLocation, let their know that
+                    alert('Please activate Geolocation and refresh the page. If it is already active, please check permissions for this website.');
+                    return;
+                }
+
+                if (err.code === 3) {
+                    console.error('Cannot retrieve GPS position. Signal is absent.');
+                    return;
+                }
+            };
+        }
+
+        if ('geolocation' in navigator === false) {
+            onError({ code: 0, message: 'Geolocation is not supported by your browser' });
+            return Promise.resolve();
+        }
+
+        // https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/watchPosition
+        return navigator.geolocation.watchPosition(onSuccess, onError, {
+            enableHighAccuracy: true,
+            maximumAge: 0,
+            timeout: 27000,
+        });
+    },
+
+    /**
+     * Update user position.
+     *
+     * @returns {void}
+     */
+    _updatePosition: function () {
+        // don't update if accuracy is not good enough
+        if (this.currentCoords.accuracy > this.data.positionMinAccuracy) {
+            if (this.data.alert && !document.getElementById('alert-popup')) {
+                var popup = document.createElement('div');
+                popup.innerHTML = 'GPS signal is very poor. Try move outdoor or to an area with a better signal.'
+                popup.setAttribute('id', 'alert-popup');
+                document.body.appendChild(popup);
+            }
+            return;
+        }
+
+        var alertPopup = document.getElementById('alert-popup');
+        if (this.currentCoords.accuracy <= this.data.positionMinAccuracy && alertPopup) {
+            document.body.removeChild(alertPopup);
+        }
+
+        if (!this.originCoordsProjected) {
+            // first camera initialization
+            // Now store originCoordsProjected as PROJECTED original lat/lon, so that
+            // we can set the world origin to the original position in "metres"
+            this.originCoordsProjected = this._project(this.currentCoords.latitude, this.currentCoords.longitude);
+            this._setPosition();
+
+            var loader = document.querySelector('.arjs-loader');
+            if (loader) {
+                loader.remove();
+            }
+            window.dispatchEvent(new CustomEvent('gps-camera-origin-coord-set'));
+        } else {
+            this._setPosition();
+        }
+    },
+    /**
+     * Set the current position (in world coords, based on Spherical Mercator)
+     *
+     * @returns {void}
+     */
+    _setPosition: function () {
+        var position = this.el.getAttribute('position');
+
+        var worldCoords = this.latLonToWorld(this.currentCoords.latitude, this.currentCoords.longitude);
+
+        position.x = worldCoords[0];
+        position.z = worldCoords[1]; 
+
+        // update position
+        this.el.setAttribute('position', position);
+
+        // add the sphmerc position to the event (for testing only)
+        window.dispatchEvent(new CustomEvent('gps-camera-update-position', { detail: { position: this.currentCoords, origin: this.originCoordsProjected } }));
+    },
+    /**
+     * Returns distance in meters between camera and destination input.
+     *
+     * Assume we are using a metre-based projection. Not all 'metre-based'
+     * projections give exact metres, e.g. Spherical Mercator, but it appears 
+     * close enough to be used for AR at least in middle temperate 
+     * latitudes (40 - 55). It is heavily distorted near the poles, however.
+     *
+     * @param {Position} dest
+     * @param {Boolean} isPlace
+     *
+     * @returns {number} distance | Number.MAX_SAFE_INTEGER
+     */
+    computeDistanceMeters: function (dest, isPlace) {
+        var src = this.el.getAttribute("position");
+        var dx = dest.x - src.x;
+        var dz = dest.z - src.z;
+        var distance = Math.sqrt(dx * dx + dz * dz);
+
+        // if function has been called for a place, and if it's too near and a min distance has been set,
+        // return max distance possible - to be handled by the  method caller
+        if (isPlace && this.data.minDistance && this.data.minDistance > 0 && distance < this.data.minDistance) {
+            return Number.MAX_SAFE_INTEGER;
+        }
+
+        return distance;
+    },
+    /**
+     * Converts latitude/longitude to OpenGL world coordinates. 
+     *
+     * First projects lat/lon to absolute Spherical Mercator and then 
+     * calculates the world coordinates by comparing the Spherical Mercator
+     * coordinates with the Spherical Mercator coordinates of the origin point.
+     *
+     * @param {Number} lat 
+     * @param {Number} lon 
+     *
+     * @returns {array} world coordinates 
+     */
+    latLonToWorld: function(lat, lon) {
+        var projected = this._project (lat, lon);
+        // Sign of z needs to be reversed compared to projected coordinates
+        return [ projected[0] - this.originCoordsProjected[0], -(projected[1] - this.originCoordsProjected[1]) ];
+    },
+    /**
+     * Converts latitude/longitude to Spherical Mercator coordinates. 
+     * Algorithm is used in several OpenStreetMap-related applications.
+     *
+     * @param {Number} lat 
+     * @param {Number} lon 
+     *
+     * @returns {array} Spherical Mercator coordinates 
+     */
+    _project: function (lat, lon) {
+        const HALF_EARTH = 20037508.34;
+
+        // Convert the supplied coords to Spherical Mercator (EPSG:3857), also
+        // known as 'Google Projection', using the algorithm used extensively 
+        // in various OpenStreetMap software.
+        var y = Math.log(Math.tan((90 + lat) * Math.PI / 360.0)) / (Math.PI / 180.0);
+        return [ (lon / 180.0) * HALF_EARTH, y * HALF_EARTH / 180.0 ];
+    },
+    /**
+     * Converts Spherical Mercator coordinates to latitude/longitude.
+     * Algorithm is used in several OpenStreetMap-related applications.
+     *
+     * @param {Number} spherical mercator easting 
+     * @param {Number} spherical mercator northing 
+     *
+     * @returns {object} lon/lat
+     */
+    _unproject: function (e, n) {
+        const HALF_EARTH = 20037508.34;
+        var yp = (n / HALF_EARTH) * 180.0;
+        return { 
+            longitude: (e / HALF_EARTH) * 180.0,
+            latitude: 180.0 / Math.PI * (2 * Math.atan(Math.exp(yp * Math.PI / 180.0)) - Math.PI / 2)
+        };
+    },
+    /**
+     * Compute compass heading.
+     *
+     * @param {number} alpha
+     * @param {number} beta
+     * @param {number} gamma
+     *
+     * @returns {number} compass heading
+     */
+    _computeCompassHeading: function (alpha, beta, gamma) {
+
+        // Convert degrees to radians
+        var alphaRad = alpha * (Math.PI / 180);
+        var betaRad = beta * (Math.PI / 180);
+        var gammaRad = gamma * (Math.PI / 180);
+
+        // Calculate equation components
+        var cA = Math.cos(alphaRad);
+        var sA = Math.sin(alphaRad);
+        var sB = Math.sin(betaRad);
+        var cG = Math.cos(gammaRad);
+        var sG = Math.sin(gammaRad);
+
+        // Calculate A, B, C rotation components
+        var rA = - cA * sG - sA * sB * cG;
+        var rB = - sA * sG + cA * sB * cG;
+
+        // Calculate compass heading
+        var compassHeading = Math.atan(rA / rB);
+
+        // Convert from half unit circle to whole unit circle
+        if (rB < 0) {
+            compassHeading += Math.PI;
+        } else if (rA < 0) {
+            compassHeading += 2 * Math.PI;
+        }
+
+        // Convert radians to degrees
+        compassHeading *= 180 / Math.PI;
+
+        return compassHeading;
+    },
+
+    /**
+     * Handler for device orientation event.
+     *
+     * @param {Event} event
+     * @returns {void}
+     */
+    _onDeviceOrientation: function (event) {
+        if (event.webkitCompassHeading !== undefined) {
+            if (event.webkitCompassAccuracy < 50) {
+                this.heading = event.webkitCompassHeading;
+            } else {
+                console.warn('webkitCompassAccuracy is event.webkitCompassAccuracy');
+            }
+        } else if (event.alpha !== null) {
+            if (event.absolute === true || event.absolute === undefined) {
+                this.heading = this._computeCompassHeading(event.alpha, event.beta, event.gamma);
+            } else {
+                console.warn('event.absolute === false');
+            }
+        } else {
+            console.warn('event.alpha === null');
+        }
+    },
+
+    /**
+     * Update user rotation data.
+     *
+     * @returns {void}
+     */
+    _updateRotation: function () {
+        var heading = 360 - this.heading;
+        var cameraRotation = this.el.getAttribute('rotation').y;
+        var yawRotation = THREE.Math.radToDeg(this.lookControls.yawObject.rotation.y);
+        var offset = (heading - (cameraRotation - yawRotation)) % 360;
+        this.lookControls.yawObject.rotation.y = THREE.Math.degToRad(offset);
+    },
+});
+/** gps-projected-entity-place
+ *
+ * based on the original gps-entity-place, modified by nickw 02/04/20
+ *
+ * Rather than keeping track of position by calculating the distance of
+ * entities or the current location to the original location, this version
+ * makes use of the "Google" Spherical Mercactor projection, aka epsg:3857.
+ *
+ * The original location on startup (lat/lon) is projected into Spherical 
+ * Mercator and stored.
+ *
+ * When 'entity-places' are added, their Spherical Mercator coords are 
+ * calculated and converted into world coordinates, relative to the original
+ * position, using the Spherical Mercator projection calculation in
+ * gps-projected-camera.
+ *
+ * Spherical Mercator units are close to, but not exactly, metres, and are
+ * heavily distorted near the poles. Nonetheless they are a good approximation
+ * for many areas of the world and appear not to cause unacceptable distortions
+ * when used as the units for AR apps.
+ */
+AFRAME.registerComponent('gps-projected-entity-place', {
+    _cameraGps: null,
+    schema: {
+        longitude: {
+            type: 'number',
+            default: 0,
+        },
+        latitude: {
+            type: 'number',
+            default: 0,
+        },
+        elevation: {
+            type: 'number',
+            default: 0
+        }
+    },
+    remove: function() {
+        // cleaning listeners when the entity is removed from the DOM
+        window.removeEventListener('gps-camera-update-position', this.updatePositionListener);
+    },
+    init: function() {
+        // Used now to get the GPS camera when it's been setup
+        this.coordSetListener = () => {
+            if (!this._cameraGps) {
+                var camera = document.querySelector('[gps-projected-camera]');
+                if (!camera.components['gps-projected-camera']) {
+                    console.error('gps-projected-camera not initialized')
+                    return;
+                }
+                this._cameraGps = camera.components['gps-projected-camera'];
+                this._updatePosition();
+            }
+        };
+        
+
+
+        // update position needs to worry about distance but nothing else?
+        this.updatePositionListener = (ev) => {
+            if (!this.data || !this._cameraGps) {
+                return;
+            }
+
+            var dstCoords = this.getAttribute('position');
+
+            // it's actually a 'distance place', but we don't call it with last param, because we want to retrieve distance even if it's < minDistance property
+            // _computeDistanceMeters is now going to use the projected
+            var distanceForMsg = this._cameraGps.computeDistanceMeters(dstCoords);
+
+            this.el.setAttribute('distance', distanceForMsg);
+            this.el.setAttribute('distanceMsg', formatDistance(distanceForMsg));
+
+            this.el.dispatchEvent(new CustomEvent('gps-entity-place-update-positon', { detail: { distance: distanceForMsg } }));
+
+            var actualDistance = this._cameraGps.computeDistanceMeters(dstCoords, true);
+
+            if (actualDistance === Number.MAX_SAFE_INTEGER) {
+                this.hideForMinDistance(this.el, true);
+            } else {
+                this.hideForMinDistance(this.el, false);
+            }
+        };
+
+        // Retain as this event is fired when the GPS camera is set up
+        window.addEventListener('gps-camera-origin-coord-set', this.coordSetListener);
+        window.addEventListener('gps-camera-update-position', this.updatePositionListener);
+
+        this._positionXDebug = 0;
+
+        window.dispatchEvent(new CustomEvent('gps-entity-place-added', { detail: { component: this.el } }));
+    },
+    /**
+     * Hide entity according to minDistance property
+     * @returns {void}
+     */
+    hideForMinDistance: function(el, hideEntity) {
+        if (hideEntity) {
+            el.setAttribute('visible', 'false');
+        } else {
+            el.setAttribute('visible', 'true');
+        }
+    },
+    /**
+     * Update place position
+     * @returns {void}
+     */
+
+    // set position to world coords using the lat/lon 
+    _updatePosition: function() {
+        var pos = this._cameraGps.latLonToWorld(this.data.latitude, this.data.longitude);
+        // update element's position in 3D world
+        //this.el.setAttribute('position', position);
+        this.el.setAttribute('position', {
+            x: pos[0],
+            y: this.data.elevation,
+            z: pos[1]
+        }); 
+    },
+});
+
+/**
+ * Format distances string
+ *
+ * @param {String} distance
+ */
+function formatDistance(distance) {
+    distance = distance.toFixed(0);
+
+    if (distance >= 1000) {
+        return (distance / 1000) + ' kilometers';
+    }
+
+    return distance + ' meters';
+};
 AFRAME.registerSystem('arjs', {
     schema: {
         trackingMethod: {

--- a/aframe/src/location-based/gps-projected-camera.js
+++ b/aframe/src/location-based/gps-projected-camera.js
@@ -1,0 +1,423 @@
+/** gps-projected-camera
+ *
+ * based on the original gps-camera, modified by nickw 02/04/20
+ *
+ * Rather than keeping track of position by calculating the distance of
+ * entities or the current location to the original location, this version
+ * makes use of the "Google" Spherical Mercactor projection, aka epsg:3857.
+ *
+ * The original position (lat/lon) is projected into Spherical Mercator and
+ * stored.
+ *
+ * Then, when we receive a new position (lat/lon), this new position is
+ * projected into Spherical Mercator and then its world position calculated
+ * by comparing against the original position.
+ *
+ * The same is also the case for 'entity-places'; when these are added, their
+ * Spherical Mercator coords are calculated (see gps-projected-entity-place).
+ *
+ * Spherical Mercator units are close to, but not exactly, metres, and are
+ * heavily distorted near the poles. Nonetheless they are a good approximation
+ * for many areas of the world and appear not to cause unacceptable distortions
+ * when used as the units for AR apps.
+ */
+
+AFRAME.registerComponent('gps-projected-camera', {
+    _watchPositionId: null,
+    originCoordsProjected: null, // original coords now in Spherical Mercator
+    currentCoords: null,
+    lookControls: null,
+    heading: null,
+    schema: {
+        simulateLatitude: {
+            type: 'number',
+            default: 0,
+        },
+        simulateLongitude: {
+            type: 'number',
+            default: 0,
+        },
+        simulateAltitude: {
+            type: 'number',
+            default: 0,
+        },
+        positionMinAccuracy: {
+            type: 'int',
+            default: 100,
+        },
+        alert: {
+            type: 'boolean',
+            default: false,
+        },
+        minDistance: {
+            type: 'int',
+            default: 0,
+        }
+    },
+    update: function() {
+        if (this.data.simulateLatitude !== 0 && this.data.simulateLongitude !== 0) {
+            localPosition = Object.assign({}, this.currentCoords || {});
+            localPosition.longitude = this.data.simulateLongitude;
+            localPosition.latitude = this.data.simulateLatitude;
+            localPosition.altitude = this.data.simulateAltitude;
+            this.currentCoords = localPosition;
+
+            // re-trigger initialization for new origin
+            this.originCoordsProjected = null;
+            this._updatePosition();
+        }
+    },
+    init: function () {
+        if (!this.el.components['look-controls']) {
+            return;
+        }
+
+        this.loader = document.createElement('DIV');
+        this.loader.classList.add('arjs-loader');
+        document.body.appendChild(this.loader);
+
+        window.addEventListener('gps-entity-place-added', function () {
+            // if places are added after camera initialization is finished
+            if (this.originCoordsProjected) {
+                window.dispatchEvent(new CustomEvent('gps-camera-origin-coord-set'));
+            }
+            if (this.loader && this.loader.parentElement) {
+                document.body.removeChild(this.loader)
+            }
+        }.bind(this));
+
+        this.lookControls = this.el.components['look-controls'];
+
+        // listen to deviceorientation event
+        var eventName = this._getDeviceOrientationEventName();
+        this._onDeviceOrientation = this._onDeviceOrientation.bind(this);
+
+        // if Safari
+        if (!!navigator.userAgent.match(/Version\/[\d.]+.*Safari/)) {
+            // iOS 13+
+            if (typeof DeviceOrientationEvent.requestPermission === 'function') {
+                var handler = function () {
+                    console.log('Requesting device orientation permissions...')
+                    DeviceOrientationEvent.requestPermission();
+                    document.removeEventListener('touchend', handler);
+                };
+
+                document.addEventListener('touchend', function () { handler() }, false);
+
+                alert('After camera permission prompt, please tap the screen to activate geolocation.');
+            } else {
+                var timeout = setTimeout(function () {
+                    alert('Please enable device orientation in Settings > Safari > Motion & Orientation Access.')
+                }, 750);
+                window.addEventListener(eventName, function () {
+                    clearTimeout(timeout);
+                });
+            }
+        }
+
+        window.addEventListener(eventName, this._onDeviceOrientation, false);
+
+        this._watchPositionId = this._initWatchGPS(function (position) {
+            if (this.data.simulateLatitude !== 0 && this.data.simulateLongitude !== 0) {
+                localPosition = Object.assign({}, position.coords);
+                localPosition.longitude = this.data.simulateLongitude;
+                localPosition.latitude = this.data.simulateLatitude;
+                localPosition.altitude = this.data.simulateAltitude;
+                this.currentCoords = localPosition;
+            }
+            else {
+                this.currentCoords = position.coords;
+            }
+
+            this._updatePosition();
+        }.bind(this));
+    },
+
+    tick: function () {
+        if (this.heading === null) {
+            return;
+        }
+        this._updateRotation();
+    },
+
+    remove: function () {
+        if (this._watchPositionId) {
+            navigator.geolocation.clearWatch(this._watchPositionId);
+        }
+        this._watchPositionId = null;
+
+        var eventName = this._getDeviceOrientationEventName();
+        window.removeEventListener(eventName, this._onDeviceOrientation, false);
+    },
+
+    /**
+     * Get device orientation event name, depends on browser implementation.
+     * @returns {string} event name
+     */
+    _getDeviceOrientationEventName: function () {
+        if ('ondeviceorientationabsolute' in window) {
+            var eventName = 'deviceorientationabsolute'
+        } else if ('ondeviceorientation' in window) {
+            var eventName = 'deviceorientation'
+        } else {
+            var eventName = ''
+            console.error('Compass not supported')
+        }
+
+        return eventName
+    },
+
+    /**
+     * Get current user position.
+     *
+     * @param {function} onSuccess
+     * @param {function} onError
+     * @returns {Promise}
+     */
+    _initWatchGPS: function (onSuccess, onError) {
+        if (!onError) {
+            onError = function (err) {
+                console.warn('ERROR(' + err.code + '): ' + err.message)
+
+                if (err.code === 1) {
+                    // User denied GeoLocation, let their know that
+                    alert('Please activate Geolocation and refresh the page. If it is already active, please check permissions for this website.');
+                    return;
+                }
+
+                if (err.code === 3) {
+                    alert('Cannot retrieve GPS position. Signal is absent.');
+                    return;
+                }
+            };
+        }
+
+        if ('geolocation' in navigator === false) {
+            onError({ code: 0, message: 'Geolocation is not supported by your browser' });
+            return Promise.resolve();
+        }
+
+        // https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/watchPosition
+        return navigator.geolocation.watchPosition(onSuccess, onError, {
+            enableHighAccuracy: true,
+            maximumAge: 0,
+            timeout: 27000,
+        });
+    },
+
+    /**
+     * Update user position.
+     *
+     * @returns {void}
+     */
+    _updatePosition: function () {
+        // don't update if accuracy is not good enough
+        if (this.currentCoords.accuracy > this.data.positionMinAccuracy) {
+            if (this.data.alert && !document.getElementById('alert-popup')) {
+                var popup = document.createElement('div');
+                popup.innerHTML = 'GPS signal is very poor. Try move outdoor or to an area with a better signal.'
+                popup.setAttribute('id', 'alert-popup');
+                document.body.appendChild(popup);
+            }
+            return;
+        }
+
+        var alertPopup = document.getElementById('alert-popup');
+        if (this.currentCoords.accuracy <= this.data.positionMinAccuracy && alertPopup) {
+            document.body.removeChild(alertPopup);
+        }
+
+        if (!this.originCoordsProjected) {
+            // first camera initialization
+            // Now store originCoordsProjected as PROJECTED original lat/lon, so that
+            // we can set the world origin to the original position in "metres"
+            this.originCoordsProjected = this._project(this.currentCoords.latitude, this.currentCoords.longitude);
+            this._setPosition();
+
+            var loader = document.querySelector('.arjs-loader');
+            if (loader) {
+                loader.remove();
+            }
+            window.dispatchEvent(new CustomEvent('gps-camera-origin-coord-set'));
+        } else {
+            this._setPosition();
+        }
+    },
+    /**
+     * Set the current position (in world coords, based on Spherical Mercator)
+     *
+     * @returns {void}
+     */
+    _setPosition: function () {
+        var position = this.el.getAttribute('position');
+
+        var worldCoords = this.latLonToWorld(this.currentCoords.latitude, this.currentCoords.longitude);
+
+        position.x = worldCoords[0];
+        position.z = worldCoords[1]; 
+
+        // update position
+        this.el.setAttribute('position', position);
+
+        // add the sphmerc position to the event (for testing only)
+        window.dispatchEvent(new CustomEvent('gps-camera-update-position', { detail: { position: this.currentCoords, origin: this.originCoordsProjected } }));
+    },
+    /**
+     * Returns distance in meters between camera and destination input.
+     *
+     * Assume we are using a metre-based projection. Not all 'metre-based'
+     * projections give exact metres, e.g. Spherical Mercator, but it appears 
+     * close enough to be used for AR at least in middle temperate 
+     * latitudes (40 - 55). It is heavily distorted near the poles, however.
+     *
+     * @param {Position} dest
+     * @param {Boolean} isPlace
+     *
+     * @returns {number} distance | Number.MAX_SAFE_INTEGER
+     */
+    computeDistanceMeters: function (dest, isPlace) {
+        var src = this.el.getAttribute("position");
+        var dx = dest.x - src.x;
+        var dz = dest.z - src.z;
+        var distance = Math.sqrt(dx * dx + dz * dz);
+
+        // if function has been called for a place, and if it's too near and a min distance has been set,
+        // return max distance possible - to be handled by the  method caller
+        if (isPlace && this.data.minDistance && this.data.minDistance > 0 && distance < this.data.minDistance) {
+            return Number.MAX_SAFE_INTEGER;
+        }
+
+        return distance;
+    },
+    /**
+     * Converts latitude/longitude to OpenGL world coordinates. 
+     *
+     * First projects lat/lon to absolute Spherical Mercator and then 
+     * calculates the world coordinates by comparing the Spherical Mercator
+     * coordinates with the Spherical Mercator coordinates of the origin point.
+     *
+     * @param {Number} lat 
+     * @param {Number} lon 
+     *
+     * @returns {array} world coordinates 
+     */
+    latLonToWorld: function(lat, lon) {
+        var projected = this._project (lat, lon);
+        // Sign of z needs to be reversed compared to projected coordinates
+        return [ projected[0] - this.originCoordsProjected[0], -(projected[1] - this.originCoordsProjected[1]) ];
+    },
+    /**
+     * Converts latitude/longitude to Spherical Mercator coordinates. 
+     * Algorithm is used in several OpenStreetMap-related applications.
+     *
+     * @param {Number} lat 
+     * @param {Number} lon 
+     *
+     * @returns {array} Spherical Mercator coordinates 
+     */
+    _project: function (lat, lon) {
+        const HALF_EARTH = 20037508.34;
+
+        // Convert the supplied coords to Spherical Mercator (EPSG:3857), also
+        // known as 'Google Projection', using the algorithm used extensively 
+        // in various OpenStreetMap software.
+        var y = Math.log(Math.tan((90 + lat) * Math.PI / 360.0)) / (Math.PI / 180.0);
+        return [ (lon / 180.0) * HALF_EARTH, y * HALF_EARTH / 180.0 ];
+    },
+    /**
+     * Converts Spherical Mercator coordinates to latitude/longitude.
+     * Algorithm is used in several OpenStreetMap-related applications.
+     *
+     * @param {Number} spherical mercator easting 
+     * @param {Number} spherical mercator northing 
+     *
+     * @returns {object} lon/lat
+     */
+    _unproject: function (e, n) {
+        const HALF_EARTH = 20037508.34;
+        var yp = (n / HALF_EARTH) * 180.0;
+        return { 
+            longitude: (e / HALF_EARTH) * 180.0,
+            latitude: 180.0 / Math.PI * (2 * Math.atan(Math.exp(yp * Math.PI / 180.0)) - Math.PI / 2)
+        };
+    },
+    /**
+     * Compute compass heading.
+     *
+     * @param {number} alpha
+     * @param {number} beta
+     * @param {number} gamma
+     *
+     * @returns {number} compass heading
+     */
+    _computeCompassHeading: function (alpha, beta, gamma) {
+
+        // Convert degrees to radians
+        var alphaRad = alpha * (Math.PI / 180);
+        var betaRad = beta * (Math.PI / 180);
+        var gammaRad = gamma * (Math.PI / 180);
+
+        // Calculate equation components
+        var cA = Math.cos(alphaRad);
+        var sA = Math.sin(alphaRad);
+        var sB = Math.sin(betaRad);
+        var cG = Math.cos(gammaRad);
+        var sG = Math.sin(gammaRad);
+
+        // Calculate A, B, C rotation components
+        var rA = - cA * sG - sA * sB * cG;
+        var rB = - sA * sG + cA * sB * cG;
+
+        // Calculate compass heading
+        var compassHeading = Math.atan(rA / rB);
+
+        // Convert from half unit circle to whole unit circle
+        if (rB < 0) {
+            compassHeading += Math.PI;
+        } else if (rA < 0) {
+            compassHeading += 2 * Math.PI;
+        }
+
+        // Convert radians to degrees
+        compassHeading *= 180 / Math.PI;
+
+        return compassHeading;
+    },
+
+    /**
+     * Handler for device orientation event.
+     *
+     * @param {Event} event
+     * @returns {void}
+     */
+    _onDeviceOrientation: function (event) {
+        if (event.webkitCompassHeading !== undefined) {
+            if (event.webkitCompassAccuracy < 50) {
+                this.heading = event.webkitCompassHeading;
+            } else {
+                console.warn('webkitCompassAccuracy is event.webkitCompassAccuracy');
+            }
+        } else if (event.alpha !== null) {
+            if (event.absolute === true || event.absolute === undefined) {
+                this.heading = this._computeCompassHeading(event.alpha, event.beta, event.gamma);
+            } else {
+                console.warn('event.absolute === false');
+            }
+        } else {
+            console.warn('event.alpha === null');
+        }
+    },
+
+    /**
+     * Update user rotation data.
+     *
+     * @returns {void}
+     */
+    _updateRotation: function () {
+        var heading = 360 - this.heading;
+        var cameraRotation = this.el.getAttribute('rotation').y;
+        var yawRotation = THREE.Math.radToDeg(this.lookControls.yawObject.rotation.y);
+        var offset = (heading - (cameraRotation - yawRotation)) % 360;
+        this.lookControls.yawObject.rotation.y = THREE.Math.degToRad(offset);
+    },
+});

--- a/aframe/src/location-based/gps-projected-entity-place.js
+++ b/aframe/src/location-based/gps-projected-entity-place.js
@@ -1,0 +1,134 @@
+/** gps-projected-entity-place
+ *
+ * based on the original gps-entity-place, modified by nickw 02/04/20
+ *
+ * Rather than keeping track of position by calculating the distance of
+ * entities or the current location to the original location, this version
+ * makes use of the "Google" Spherical Mercactor projection, aka epsg:3857.
+ *
+ * The original location on startup (lat/lon) is projected into Spherical 
+ * Mercator and stored.
+ *
+ * When 'entity-places' are added, their Spherical Mercator coords are 
+ * calculated and converted into world coordinates, relative to the original
+ * position, using the Spherical Mercator projection calculation in
+ * gps-projected-camera.
+ *
+ * Spherical Mercator units are close to, but not exactly, metres, and are
+ * heavily distorted near the poles. Nonetheless they are a good approximation
+ * for many areas of the world and appear not to cause unacceptable distortions
+ * when used as the units for AR apps.
+ */
+AFRAME.registerComponent('gps-projected-entity-place', {
+    _cameraGps: null,
+    schema: {
+        longitude: {
+            type: 'number',
+            default: 0,
+        },
+        latitude: {
+            type: 'number',
+            default: 0,
+        },
+        elevation: {
+            type: 'number',
+            default: 0
+        }
+    },
+    remove: function() {
+        // cleaning listeners when the entity is removed from the DOM
+        window.removeEventListener('gps-camera-update-position', this.updatePositionListener);
+    },
+    init: function() {
+        // Used now to get the GPS camera when it's been setup
+        this.coordSetListener = () => {
+            if (!this._cameraGps) {
+                var camera = document.querySelector('[gps-projected-camera]');
+                if (!camera.components['gps-projected-camera']) {
+                    console.error('gps-projected-camera not initialized')
+                    return;
+                }
+                this._cameraGps = camera.components['gps-projected-camera'];
+                this._updatePosition();
+            }
+        };
+        
+
+
+        // update position needs to worry about distance but nothing else?
+        this.updatePositionListener = (ev) => {
+            if (!this.data || !this._cameraGps) {
+                return;
+            }
+
+            var dstCoords = this.getAttribute('position');
+
+            // it's actually a 'distance place', but we don't call it with last param, because we want to retrieve distance even if it's < minDistance property
+            // _computeDistanceMeters is now going to use the projected
+            var distanceForMsg = this._cameraGps.computeDistanceMeters(dstCoords);
+
+            this.el.setAttribute('distance', distanceForMsg);
+            this.el.setAttribute('distanceMsg', formatDistance(distanceForMsg));
+
+            this.el.dispatchEvent(new CustomEvent('gps-entity-place-update-positon', { detail: { distance: distanceForMsg } }));
+
+            var actualDistance = this._cameraGps.computeDistanceMeters(dstCoords, true);
+
+            if (actualDistance === Number.MAX_SAFE_INTEGER) {
+                this.hideForMinDistance(this.el, true);
+            } else {
+                this.hideForMinDistance(this.el, false);
+            }
+        };
+
+        // Retain as this event is fired when the GPS camera is set up
+        window.addEventListener('gps-camera-origin-coord-set', this.coordSetListener);
+        window.addEventListener('gps-camera-update-position', this.updatePositionListener);
+
+        this._positionXDebug = 0;
+
+        window.dispatchEvent(new CustomEvent('gps-entity-place-added', { detail: { component: this.el } }));
+    },
+    /**
+     * Hide entity according to minDistance property
+     * @returns {void}
+     */
+    hideForMinDistance: function(el, hideEntity) {
+        if (hideEntity) {
+            el.setAttribute('visible', 'false');
+        } else {
+            el.setAttribute('visible', 'true');
+        }
+    },
+    /**
+     * Update place position
+     * @returns {void}
+     */
+
+    // set position to world coords using the lat/lon 
+    _updatePosition: function() {
+        var pos = this._cameraGps.latLonToWorld(this.data.latitude, this.data.longitude);
+        // update element's position in 3D world
+        //this.el.setAttribute('position', position);
+        this.el.setAttribute('position', {
+            x: pos[0],
+            y: this.data.elevation,
+            z: pos[1]
+        }); 
+    },
+});
+
+/**
+ * Format distances string
+ *
+ * @param {String} distance
+ */
+function formatDistance(distance) {
+    distance = distance.toFixed(0);
+
+    if (distance >= 1000) {
+        return (distance / 1000) + ' kilometers';
+    }
+
+    return distance + ' meters';
+};


### PR DESCRIPTION
…rojection 

<!-- Please, don't delete this template or we'll close your issue -->

**⚠️ All PRs have to be done versus 'dev' branch, so be aware of that, or we'll close your issue ⚠️**

**What kind of change does this PR introduce?**
<!-- Can be a new feature, a bugfix, or refactoring, etc -->

New components 'gps-projected-camera' and 'gps-projected-entity-place', which use Spherical Mercator projection to calculate the world coordinates of the current GPS location and entity-places relative to the original position.

**Can it be referenced to an Issue? If so what is the issue # ?**

#70 

**How can we test it?**
<!-- All information can be found about our tests in https://github.com/jeromeetienne/AR.js/blob/master/test/TODO.md -->
<!-- At the moment we don't explicitly require tests, because it's not streamlined yet -->

Example app at
https://hikar.org/webapp/ (for in-field testing, works throughout Europe and Turkey but data not available elsewhere)

or,  use a simulated location to view the gps-projected-entity-places:
https://hikar.org/webapp/?lat=51.049&lon=-0.723
(please disable GPS or test on non-mobile device).

If you look round you can see two nearby entity-places as a-boxes (please View Source for the HTML code) along with road and path data from OpenStreetMap rendered using the gps-projected-camera. See https://github.com/nickw1/hikar.org for source code of this project.

**Summary**
<!-- State here what problem the PR solves and what is the proposed solution -->

My use-case for using AR.js is to render OpenStreetMap 'ways' (footpaths, roads) as augmented content, to use in an AR navigation app for hikers. It is simpler in this use-case, due to the larger volume and complexity of data, just to project the whole lot into a metre-based coordinate system (Spherical Mercator) and also project the origin and current GPS position into Spherical Mercator. The projected coordinates can then be used as the basis for the WebGL world coordinates.   

**Does this PR introduce a breaking change?**

No - as original gps-camera and gps-entity-place components are left untouched.

**Please TEST your PR before proposing it. Specify here what device you have used for tests, version of OS and version of Browser**

In-the-field testing of AR roads and paths:  Pixel 3, running Chrome (latest)
Simulated location on a desktop, to test the gps-projected-entity-places: Firefox 74, Linux (Ubuntu 18.04 LTS)

**Other information**
