### PR TITLE
New Event listener for end loading of NFT marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - fixed rotation bug on X axis see issue #59, restored shift position on y instead of z
 - removed links to old repository in the examples
 - added `maxDistance` property on location-based
+- new `arjs-nft-loaded` event listener for **NFT** markers, dispatched when all **NFT** markers are loaded see PR #98 and issue #97
 
 # 3.0.2
 

--- a/aframe/build/aframe-ar-nft.js
+++ b/aframe/build/aframe-ar-nft.js
@@ -660,6 +660,8 @@ ARjs.MarkerControls.prototype._initArtoolkit = function () {
                     if (loader) {
                         loader.remove();
                     }
+                    var endLoadingEvent = new Event('arjs-nft-loaded');
+                    window.dispatchEvent(endLoadingEvent);
                 }
 
                 if (ev && ev.data && ev.data.type === 'loaded') {

--- a/three.js/build/ar-nft.js
+++ b/three.js/build/ar-nft.js
@@ -660,6 +660,8 @@ ARjs.MarkerControls.prototype._initArtoolkit = function () {
                     if (loader) {
                         loader.remove();
                     }
+                    var endLoadingEvent = new Event('arjs-nft-loaded');
+                    window.dispatchEvent(endLoadingEvent);
                 }
 
                 if (ev && ev.data && ev.data.type === 'loaded') {

--- a/three.js/examples/nft.html
+++ b/three.js/examples/nft.html
@@ -114,6 +114,11 @@
             onResize()
         })
 
+        // listener for end loading of NFT marker
+        window.addEventListener('arjs-nft-loaded', function(ev){
+          console.log(ev);
+        })
+
         function onResize(){
             arToolkitSource.onResizeElement()
             arToolkitSource.copyElementSizeTo(renderer.domElement)

--- a/three.js/src/threex/threex-armarkercontrols-nft-start.js
+++ b/three.js/src/threex/threex-armarkercontrols-nft-start.js
@@ -328,6 +328,8 @@ ARjs.MarkerControls.prototype._initArtoolkit = function () {
                     if (loader) {
                         loader.remove();
                     }
+                    var endLoadingEvent = new Event('arjs-nft-loaded');
+                    window.dispatchEvent(endLoadingEvent);
                 }
 
                 if (ev && ev.data && ev.data.type === 'loaded') {


### PR DESCRIPTION
<!-- Please, don't delete this template or we'll close your issue -->

**⚠️ All PRs have to be done versus 'dev' branch, so be aware of that, or we'll close your issue ⚠️**

**What kind of change does this PR introduce?**
<!-- Can be a new feature, a bugfix, or refactoring, etc -->
This **PR** add an Event Listener **`arjs-nft-loaded`** that is dispatched immediately after all **NFT** markers all loaded.
To know if the NFT markers are loaded, add an addEventListener:

```javascript
window.addEventListener('arjs-nft-loaded', function(ev){
// do something witth the ev event...
 })
```

**Can it be referenced to an Issue? If so what is the issue # ?**
Discussed in issue https://github.com/AR-js-org/AR.js/issues/97
**How can we test it?**
Test the [three.js/examples/nft,html](https://github.com/AR-js-org/AR.js/blob/master/three.js/examples/nft.html) open the dev console and when the **NFT** markers are all loaded you will see the event fired:

`Event {isTrusted: false, type: "arjs-nft-loaded", target: Window, currentTarget: Window, eventPhase: 2, …}isTrusted: falsetype: "arjs-nft-loaded"target: Window {parent: Window, opener: null, top: Window, length: 0, frames: Window, …}currentTarget: Window {parent: Window, opener: null, top: Window, length: 0, frames: Window, …}eventPhase: 0bubbles: falsecancelable: falsedefaultPrevented: falsecomposed: falsetimeStamp: 23275.25500000047srcElement: Window {parent: Window, opener: null, top: Window, length: 0, frames: Window, …}returnValue: truecancelBubble: falsepath: [Window]__proto__: Event
`
<!-- All information can be found about our tests in https://github.com/jeromeetienne/AR.js/blob/master/test/TODO.md -->
<!-- At the moment we don't explicitly require tests, because it's not streamlined yet -->

**Summary**
<!-- State here what problem the PR solves and what is the proposed solution -->
This is an enhancement for **AR.js**
**Does this PR introduce a breaking change?**
No, absolutely.
**Please TEST your PR before proposing it. Specify here what device you have used for tests, version of OS and version of Browser**
Tested on desktop: Ubuntu 18.04
**Other information**
