### PR TITLE
Partial fix of #110 (distant augmented data not visible even if within the viewing frustum)

### DIFF
--- a/aframe/Makefile
+++ b/aframe/Makefile
@@ -21,4 +21,7 @@ build-nft:
 		src/system-arjs.js	\
 		> build/aframe-ar-nft.js
 
+build-location-only:
+	cat src/location-based/*.js > build/aframe-ar-location-only.js
+
 build: build-default build-nft

--- a/aframe/build/aframe-ar-location-only.js
+++ b/aframe/build/aframe-ar-location-only.js
@@ -1,0 +1,1085 @@
+AFRAME.registerComponent('arjs-webcam-texture', {
+
+    init: function() {
+        this.scene = this.el.sceneEl;
+        this.texCamera = new THREE.OrthographicCamera(-0.5, 0.5, 0.5, -0.5, 0, 10);
+        this.texScene = new THREE.Scene();
+
+        this.scene.renderer.autoClear = false;
+        const video = document.createElement("video");
+        video.setAttribute("autoplay", true);
+        video.setAttribute("display", "none");
+        document.body.appendChild(video);
+        const geom = new THREE.PlaneBufferGeometry(); //0.5, 0.5);
+        const texture = new THREE.VideoTexture(video);
+        const material = new THREE.MeshBasicMaterial( { map: texture } );
+        const mesh = new THREE.Mesh(geom, material);
+        this.texScene.add(mesh);
+        if(navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
+            const constraints = { video: {
+                width: 1280,
+                height: 720,
+                facingMode: 'user' }
+            };
+            navigator.mediaDevices.getUserMedia(constraints).then( stream=> {
+                video.srcObject = stream;    
+                video.play();
+            })
+            .catch(e => { alert(`Webcam error: ${e}`); });
+        } else {
+            alert('sorry - media devices API not supported');
+        }
+    },
+
+    tick: function() {
+        this.scene.renderer.clear();
+        this.scene.renderer.render(this.texScene, this.texCamera);
+        this.scene.renderer.clearDepth();
+    }
+});
+AFRAME.registerComponent('gps-camera', {
+    _watchPositionId: null,
+    originCoords: null,
+    currentCoords: null,
+    lookControls: null,
+    heading: null,
+    schema: {
+        simulateLatitude: {
+            type: 'number',
+            default: 0,
+        },
+        simulateLongitude: {
+            type: 'number',
+            default: 0,
+        },
+        simulateAltitude: {
+            type: 'number',
+            default: 0,
+        },
+        positionMinAccuracy: {
+            type: 'int',
+            default: 100,
+        },
+        alert: {
+            type: 'boolean',
+            default: false,
+        },
+        minDistance: {
+            type: 'int',
+            default: 0,
+        },
+        maxDistance: {
+            type: 'int',
+            default: 0,
+        }
+    },
+    update: function() {
+        if (this.data.simulateLatitude !== 0 && this.data.simulateLongitude !== 0) {
+            localPosition = Object.assign({}, this.currentCoords || {});
+            localPosition.longitude = this.data.simulateLongitude;
+            localPosition.latitude = this.data.simulateLatitude;
+            localPosition.altitude = this.data.simulateAltitude;
+            this.currentCoords = localPosition;
+
+            // re-trigger initialization for new origin
+            this.originCoords = null;
+            this._updatePosition();
+        }
+    },
+    init: function () {
+        if (!this.el.components['look-controls']) {
+            return;
+        }
+
+        this.loader = document.createElement('DIV');
+        this.loader.classList.add('arjs-loader');
+        document.body.appendChild(this.loader);
+
+        window.addEventListener('gps-entity-place-added', function () {
+            // if places are added after camera initialization is finished
+            if (this.originCoords) {
+                window.dispatchEvent(new CustomEvent('gps-camera-origin-coord-set'));
+            }
+            if (this.loader && this.loader.parentElement) {
+                document.body.removeChild(this.loader)
+            }
+        }.bind(this));
+
+        this.lookControls = this.el.components['look-controls'];
+
+        // listen to deviceorientation event
+        var eventName = this._getDeviceOrientationEventName();
+        this._onDeviceOrientation = this._onDeviceOrientation.bind(this);
+
+        // if Safari
+        if (!!navigator.userAgent.match(/Version\/[\d.]+.*Safari/)) {
+            // iOS 13+
+            if (typeof DeviceOrientationEvent.requestPermission === 'function') {
+                var handler = function () {
+                    console.log('Requesting device orientation permissions...')
+                    DeviceOrientationEvent.requestPermission();
+                    document.removeEventListener('touchend', handler);
+                };
+
+                document.addEventListener('touchend', function () { handler() }, false);
+
+                alert('After camera permission prompt, please tap the screen to activate geolocation.');
+            } else {
+                var timeout = setTimeout(function () {
+                    alert('Please enable device orientation in Settings > Safari > Motion & Orientation Access.')
+                }, 750);
+                window.addEventListener(eventName, function () {
+                    clearTimeout(timeout);
+                });
+            }
+        }
+
+        window.addEventListener(eventName, this._onDeviceOrientation, false);
+
+        this._watchPositionId = this._initWatchGPS(function (position) {
+            if (this.data.simulateLatitude !== 0 && this.data.simulateLongitude !== 0) {
+                localPosition = Object.assign({}, position.coords);
+                localPosition.longitude = this.data.simulateLongitude;
+                localPosition.latitude = this.data.simulateLatitude;
+                localPosition.altitude = this.data.simulateAltitude;
+                this.currentCoords = localPosition;
+            }
+            else {
+                this.currentCoords = position.coords;
+            }
+
+            this._updatePosition();
+        }.bind(this));
+    },
+
+    tick: function () {
+        if (this.heading === null) {
+            return;
+        }
+        this._updateRotation();
+    },
+
+    remove: function () {
+        if (this._watchPositionId) {
+            navigator.geolocation.clearWatch(this._watchPositionId);
+        }
+        this._watchPositionId = null;
+
+        var eventName = this._getDeviceOrientationEventName();
+        window.removeEventListener(eventName, this._onDeviceOrientation, false);
+    },
+
+    /**
+     * Get device orientation event name, depends on browser implementation.
+     * @returns {string} event name
+     */
+    _getDeviceOrientationEventName: function () {
+        if ('ondeviceorientationabsolute' in window) {
+            var eventName = 'deviceorientationabsolute'
+        } else if ('ondeviceorientation' in window) {
+            var eventName = 'deviceorientation'
+        } else {
+            var eventName = ''
+            console.error('Compass not supported')
+        }
+
+        return eventName
+    },
+
+    /**
+     * Get current user position.
+     *
+     * @param {function} onSuccess
+     * @param {function} onError
+     * @returns {Promise}
+     */
+    _initWatchGPS: function (onSuccess, onError) {
+        if (!onError) {
+            onError = function (err) {
+                console.warn('ERROR(' + err.code + '): ' + err.message)
+
+                if (err.code === 1) {
+                    // User denied GeoLocation, let their know that
+                    alert('Please activate Geolocation and refresh the page. If it is already active, please check permissions for this website.');
+                    return;
+                }
+
+                if (err.code === 3) {
+                    alert('Cannot retrieve GPS position. Signal is absent.');
+                    return;
+                }
+            };
+        }
+
+        if ('geolocation' in navigator === false) {
+            onError({ code: 0, message: 'Geolocation is not supported by your browser' });
+            return Promise.resolve();
+        }
+
+        // https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/watchPosition
+        return navigator.geolocation.watchPosition(onSuccess, onError, {
+            enableHighAccuracy: true,
+            maximumAge: 0,
+            timeout: 27000,
+        });
+    },
+
+    /**
+     * Update user position.
+     *
+     * @returns {void}
+     */
+    _updatePosition: function () {
+        // don't update if accuracy is not good enough
+        if (this.currentCoords.accuracy > this.data.positionMinAccuracy) {
+            if (this.data.alert && !document.getElementById('alert-popup')) {
+                var popup = document.createElement('div');
+                popup.innerHTML = 'GPS signal is very poor. Try move outdoor or to an area with a better signal.'
+                popup.setAttribute('id', 'alert-popup');
+                document.body.appendChild(popup);
+            }
+            return;
+        }
+
+        var alertPopup = document.getElementById('alert-popup');
+        if (this.currentCoords.accuracy <= this.data.positionMinAccuracy && alertPopup) {
+            document.body.removeChild(alertPopup);
+        }
+
+        if (!this.originCoords) {
+            // first camera initialization
+            this.originCoords = this.currentCoords;
+            this._setPosition();
+
+            var loader = document.querySelector('.arjs-loader');
+            if (loader) {
+                loader.remove();
+            }
+            window.dispatchEvent(new CustomEvent('gps-camera-origin-coord-set'));
+        } else {
+            this._setPosition();
+        }
+    },
+    _setPosition: function () {
+        var position = this.el.getAttribute('position');
+
+        // compute position.x
+        var dstCoords = {
+            longitude: this.currentCoords.longitude,
+            latitude: this.originCoords.latitude,
+        };
+
+        position.x = this.computeDistanceMeters(this.originCoords, dstCoords);
+        position.x *= this.currentCoords.longitude > this.originCoords.longitude ? 1 : -1;
+
+        // compute position.z
+        var dstCoords = {
+            longitude: this.originCoords.longitude,
+            latitude: this.currentCoords.latitude,
+        }
+
+        position.z = this.computeDistanceMeters(this.originCoords, dstCoords);
+        position.z *= this.currentCoords.latitude > this.originCoords.latitude ? -1 : 1;
+
+        // update position
+        this.el.setAttribute('position', position);
+
+        window.dispatchEvent(new CustomEvent('gps-camera-update-position', { detail: { position: this.currentCoords, origin: this.originCoords } }));
+    },
+    /**
+     * Returns distance in meters between source and destination inputs.
+     *
+     *  Calculate distance, bearing and more between Latitude/Longitude points
+     *  Details: https://www.movable-type.co.uk/scripts/latlong.html
+     *
+     * @param {Position} src
+     * @param {Position} dest
+     * @param {Boolean} isPlace
+     *
+     * @returns {number} distance | Number.MAX_SAFE_INTEGER
+     */
+    computeDistanceMeters: function (src, dest, isPlace) {
+        var dlongitude = THREE.Math.degToRad(dest.longitude - src.longitude);
+        var dlatitude = THREE.Math.degToRad(dest.latitude - src.latitude);
+
+        var a = (Math.sin(dlatitude / 2) * Math.sin(dlatitude / 2)) + Math.cos(THREE.Math.degToRad(src.latitude)) * Math.cos(THREE.Math.degToRad(dest.latitude)) * (Math.sin(dlongitude / 2) * Math.sin(dlongitude / 2));
+        var angle = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        var distance = angle * 6378160;
+
+        // if function has been called for a place, and if it's too near and a min distance has been set,
+        // return max distance possible - to be handled by the caller
+        if (isPlace && this.data.minDistance && this.data.minDistance > 0 && distance < this.data.minDistance) {
+            return Number.MAX_SAFE_INTEGER;
+        }
+
+        // if function has been called for a place, and if it's too far and a max distance has been set,
+        // return max distance possible - to be handled by the caller
+        if (isPlace && this.data.maxDistance && this.data.maxDistance > 0 && distance > this.data.maxDistance) {
+            return Number.MAX_SAFE_INTEGER;
+        }
+
+        return distance;
+    },
+
+    /**
+     * Compute compass heading.
+     *
+     * @param {number} alpha
+     * @param {number} beta
+     * @param {number} gamma
+     *
+     * @returns {number} compass heading
+     */
+    _computeCompassHeading: function (alpha, beta, gamma) {
+
+        // Convert degrees to radians
+        var alphaRad = alpha * (Math.PI / 180);
+        var betaRad = beta * (Math.PI / 180);
+        var gammaRad = gamma * (Math.PI / 180);
+
+        // Calculate equation components
+        var cA = Math.cos(alphaRad);
+        var sA = Math.sin(alphaRad);
+        var sB = Math.sin(betaRad);
+        var cG = Math.cos(gammaRad);
+        var sG = Math.sin(gammaRad);
+
+        // Calculate A, B, C rotation components
+        var rA = - cA * sG - sA * sB * cG;
+        var rB = - sA * sG + cA * sB * cG;
+
+        // Calculate compass heading
+        var compassHeading = Math.atan(rA / rB);
+
+        // Convert from half unit circle to whole unit circle
+        if (rB < 0) {
+            compassHeading += Math.PI;
+        } else if (rA < 0) {
+            compassHeading += 2 * Math.PI;
+        }
+
+        // Convert radians to degrees
+        compassHeading *= 180 / Math.PI;
+
+        return compassHeading;
+    },
+
+    /**
+     * Handler for device orientation event.
+     *
+     * @param {Event} event
+     * @returns {void}
+     */
+    _onDeviceOrientation: function (event) {
+        if (event.webkitCompassHeading !== undefined) {
+            if (event.webkitCompassAccuracy < 50) {
+                this.heading = event.webkitCompassHeading;
+            } else {
+                console.warn('webkitCompassAccuracy is event.webkitCompassAccuracy');
+            }
+        } else if (event.alpha !== null) {
+            if (event.absolute === true || event.absolute === undefined) {
+                this.heading = this._computeCompassHeading(event.alpha, event.beta, event.gamma);
+            } else {
+                console.warn('event.absolute === false');
+            }
+        } else {
+            console.warn('event.alpha === null');
+        }
+    },
+
+    /**
+     * Update user rotation data.
+     *
+     * @returns {void}
+     */
+    _updateRotation: function () {
+        var heading = 360 - this.heading;
+        var cameraRotation = this.el.getAttribute('rotation').y;
+        var yawRotation = THREE.Math.radToDeg(this.lookControls.yawObject.rotation.y);
+        var offset = (heading - (cameraRotation - yawRotation)) % 360;
+        this.lookControls.yawObject.rotation.y = THREE.Math.degToRad(offset);
+    },
+});
+AFRAME.registerComponent('gps-entity-place', {
+    _cameraGps: null,
+    schema: {
+        longitude: {
+            type: 'number',
+            default: 0,
+        },
+        latitude: {
+            type: 'number',
+            default: 0,
+        }
+    },
+    remove: function() {
+        // cleaning listeners when the entity is removed from the DOM
+        window.removeEventListener('gps-camera-origin-coord-set', this.coordSetListener);
+        window.removeEventListener('gps-camera-update-position', this.updatePositionListener);
+    },
+    init: function() {
+        this.coordSetListener = () => {
+            if (!this._cameraGps) {
+                var camera = document.querySelector('[gps-camera]');
+                if (!camera.components['gps-camera']) {
+                    console.error('gps-camera not initialized')
+                    return;
+                }
+                this._cameraGps = camera.components['gps-camera'];
+            }
+            this._updatePosition();
+        };
+
+        this.updatePositionListener = (ev) => {
+            if (!this.data || !this._cameraGps) {
+                return;
+            }
+
+            var dstCoords = {
+                longitude: this.data.longitude,
+                latitude: this.data.latitude,
+            };
+
+            // it's actually a 'distance place', but we don't call it with last param, because we want to retrieve distance even if it's < minDistance property
+            var distanceForMsg = this._cameraGps.computeDistanceMeters(ev.detail.position, dstCoords);
+
+            this.el.setAttribute('distance', distanceForMsg);
+            this.el.setAttribute('distanceMsg', formatDistance(distanceForMsg));
+            this.el.dispatchEvent(new CustomEvent('gps-entity-place-update-positon', { detail: { distance: distanceForMsg } }));
+
+            var actualDistance = this._cameraGps.computeDistanceMeters(ev.detail.position, dstCoords, true);
+
+            if (actualDistance === Number.MAX_SAFE_INTEGER) {
+                this.hideForMinDistance(this.el, true);
+            } else {
+                this.hideForMinDistance(this.el, false);
+            }
+        };
+
+        window.addEventListener('gps-camera-origin-coord-set', this.coordSetListener);
+        window.addEventListener('gps-camera-update-position', this.updatePositionListener);
+
+        this._positionXDebug = 0;
+
+        window.dispatchEvent(new CustomEvent('gps-entity-place-added', { detail: { component: this.el } }));
+    },
+    /**
+     * Hide entity according to minDistance property
+     * @returns {void}
+     */
+    hideForMinDistance: function(el, hideEntity) {
+        if (hideEntity) {
+            el.setAttribute('visible', 'false');
+        } else {
+            el.setAttribute('visible', 'true');
+        }
+    },
+    /**
+     * Update place position
+     * @returns {void}
+     */
+    _updatePosition: function() {
+        var position = { x: 0, y: this.el.getAttribute('position').y || 0, z: 0 }
+
+        // update position.x
+        var dstCoords = {
+            longitude: this.data.longitude,
+            latitude: this._cameraGps.originCoords.latitude,
+        };
+
+        position.x = this._cameraGps.computeDistanceMeters(this._cameraGps.originCoords, dstCoords);
+
+        this._positionXDebug = position.x;
+
+        position.x *= this.data.longitude > this._cameraGps.originCoords.longitude ? 1 : -1;
+
+        // update position.z
+        var dstCoords = {
+            longitude: this._cameraGps.originCoords.longitude,
+            latitude: this.data.latitude,
+        };
+
+        position.z = this._cameraGps.computeDistanceMeters(this._cameraGps.originCoords, dstCoords);
+
+        position.z *= this.data.latitude > this._cameraGps.originCoords.latitude ? -1 : 1;
+
+        if (position.y !== 0) {
+            var altitude = this._cameraGps.originCoords.altitude !== undefined ? this._cameraGps.originCoords.altitude : 0;
+            position.y = position.y - altitude;
+        }
+
+        // update element's position in 3D world
+        this.el.setAttribute('position', position);
+    },
+});
+
+/**
+ * Format distances string
+ *
+ * @param {String} distance
+ */
+function formatDistance(distance) {
+    distance = distance.toFixed(0);
+
+    if (distance >= 1000) {
+        return (distance / 1000) + ' kilometers';
+    }
+
+    return distance + ' meters';
+};
+/** gps-projected-camera
+ *
+ * based on the original gps-camera, modified by nickw 02/04/20
+ *
+ * Rather than keeping track of position by calculating the distance of
+ * entities or the current location to the original location, this version
+ * makes use of the "Google" Spherical Mercactor projection, aka epsg:3857.
+ *
+ * The original position (lat/lon) is projected into Spherical Mercator and
+ * stored.
+ *
+ * Then, when we receive a new position (lat/lon), this new position is
+ * projected into Spherical Mercator and then its world position calculated
+ * by comparing against the original position.
+ *
+ * The same is also the case for 'entity-places'; when these are added, their
+ * Spherical Mercator coords are calculated (see gps-projected-entity-place).
+ *
+ * Spherical Mercator units are close to, but not exactly, metres, and are
+ * heavily distorted near the poles. Nonetheless they are a good approximation
+ * for many areas of the world and appear not to cause unacceptable distortions
+ * when used as the units for AR apps.
+ */
+
+AFRAME.registerComponent('gps-projected-camera', {
+    _watchPositionId: null,
+    originCoordsProjected: null, // original coords now in Spherical Mercator
+    currentCoords: null,
+    lookControls: null,
+    heading: null,
+    schema: {
+        simulateLatitude: {
+            type: 'number',
+            default: 0,
+        },
+        simulateLongitude: {
+            type: 'number',
+            default: 0,
+        },
+        simulateAltitude: {
+            type: 'number',
+            default: 0,
+        },
+        positionMinAccuracy: {
+            type: 'int',
+            default: 100,
+        },
+        alert: {
+            type: 'boolean',
+            default: false,
+        },
+        minDistance: {
+            type: 'int',
+            default: 0,
+        }
+    },
+    update: function() {
+        if (this.data.simulateLatitude !== 0 && this.data.simulateLongitude !== 0) {
+            localPosition = Object.assign({}, this.currentCoords || {});
+            localPosition.longitude = this.data.simulateLongitude;
+            localPosition.latitude = this.data.simulateLatitude;
+            localPosition.altitude = this.data.simulateAltitude;
+            this.currentCoords = localPosition;
+
+            // re-trigger initialization for new origin
+            this.originCoordsProjected = null;
+            this._updatePosition();
+        }
+    },
+    init: function () {
+        if (!this.el.components['look-controls']) {
+            return;
+        }
+
+        this.loader = document.createElement('DIV');
+        this.loader.classList.add('arjs-loader');
+        document.body.appendChild(this.loader);
+
+        window.addEventListener('gps-entity-place-added', function () {
+            // if places are added after camera initialization is finished
+            if (this.originCoordsProjected) {
+                window.dispatchEvent(new CustomEvent('gps-camera-origin-coord-set'));
+            }
+            if (this.loader && this.loader.parentElement) {
+                document.body.removeChild(this.loader)
+            }
+        }.bind(this));
+
+        this.lookControls = this.el.components['look-controls'];
+
+        // listen to deviceorientation event
+        var eventName = this._getDeviceOrientationEventName();
+        this._onDeviceOrientation = this._onDeviceOrientation.bind(this);
+
+        // if Safari
+        if (!!navigator.userAgent.match(/Version\/[\d.]+.*Safari/)) {
+            // iOS 13+
+            if (typeof DeviceOrientationEvent.requestPermission === 'function') {
+                var handler = function () {
+                    console.log('Requesting device orientation permissions...')
+                    DeviceOrientationEvent.requestPermission();
+                    document.removeEventListener('touchend', handler);
+                };
+
+                document.addEventListener('touchend', function () { handler() }, false);
+
+                alert('After camera permission prompt, please tap the screen to activate geolocation.');
+            } else {
+                var timeout = setTimeout(function () {
+                    alert('Please enable device orientation in Settings > Safari > Motion & Orientation Access.')
+                }, 750);
+                window.addEventListener(eventName, function () {
+                    clearTimeout(timeout);
+                });
+            }
+        }
+
+        window.addEventListener(eventName, this._onDeviceOrientation, false);
+
+        this._watchPositionId = this._initWatchGPS(function (position) {
+            if (this.data.simulateLatitude !== 0 && this.data.simulateLongitude !== 0) {
+                localPosition = Object.assign({}, position.coords);
+                localPosition.longitude = this.data.simulateLongitude;
+                localPosition.latitude = this.data.simulateLatitude;
+                localPosition.altitude = this.data.simulateAltitude;
+                this.currentCoords = localPosition;
+            }
+            else {
+                this.currentCoords = position.coords;
+            }
+
+            this._updatePosition();
+        }.bind(this));
+    },
+
+    tick: function () {
+        if (this.heading === null) {
+            return;
+        }
+        this._updateRotation();
+    },
+
+    remove: function () {
+        if (this._watchPositionId) {
+            navigator.geolocation.clearWatch(this._watchPositionId);
+        }
+        this._watchPositionId = null;
+
+        var eventName = this._getDeviceOrientationEventName();
+        window.removeEventListener(eventName, this._onDeviceOrientation, false);
+    },
+
+    /**
+     * Get device orientation event name, depends on browser implementation.
+     * @returns {string} event name
+     */
+    _getDeviceOrientationEventName: function () {
+        if ('ondeviceorientationabsolute' in window) {
+            var eventName = 'deviceorientationabsolute'
+        } else if ('ondeviceorientation' in window) {
+            var eventName = 'deviceorientation'
+        } else {
+            var eventName = ''
+            console.error('Compass not supported')
+        }
+
+        return eventName
+    },
+
+    /**
+     * Get current user position.
+     *
+     * @param {function} onSuccess
+     * @param {function} onError
+     * @returns {Promise}
+     */
+    _initWatchGPS: function (onSuccess, onError) {
+        if (!onError) {
+            onError = function (err) {
+                console.warn('ERROR(' + err.code + '): ' + err.message)
+
+                if (err.code === 1) {
+                    // User denied GeoLocation, let their know that
+                    alert('Please activate Geolocation and refresh the page. If it is already active, please check permissions for this website.');
+                    return;
+                }
+
+                if (err.code === 3) {
+                    alert('Cannot retrieve GPS position. Signal is absent.');
+                    return;
+                }
+            };
+        }
+
+        if ('geolocation' in navigator === false) {
+            onError({ code: 0, message: 'Geolocation is not supported by your browser' });
+            return Promise.resolve();
+        }
+
+        // https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/watchPosition
+        return navigator.geolocation.watchPosition(onSuccess, onError, {
+            enableHighAccuracy: true,
+            maximumAge: 0,
+            timeout: 27000,
+        });
+    },
+
+    /**
+     * Update user position.
+     *
+     * @returns {void}
+     */
+    _updatePosition: function () {
+        // don't update if accuracy is not good enough
+        if (this.currentCoords.accuracy > this.data.positionMinAccuracy) {
+            if (this.data.alert && !document.getElementById('alert-popup')) {
+                var popup = document.createElement('div');
+                popup.innerHTML = 'GPS signal is very poor. Try move outdoor or to an area with a better signal.'
+                popup.setAttribute('id', 'alert-popup');
+                document.body.appendChild(popup);
+            }
+            return;
+        }
+
+        var alertPopup = document.getElementById('alert-popup');
+        if (this.currentCoords.accuracy <= this.data.positionMinAccuracy && alertPopup) {
+            document.body.removeChild(alertPopup);
+        }
+
+        if (!this.originCoordsProjected) {
+            // first camera initialization
+            // Now store originCoordsProjected as PROJECTED original lat/lon, so that
+            // we can set the world origin to the original position in "metres"
+            this.originCoordsProjected = this._project(this.currentCoords.latitude, this.currentCoords.longitude);
+            this._setPosition();
+
+            var loader = document.querySelector('.arjs-loader');
+            if (loader) {
+                loader.remove();
+            }
+            window.dispatchEvent(new CustomEvent('gps-camera-origin-coord-set'));
+        } else {
+            this._setPosition();
+        }
+    },
+    /**
+     * Set the current position (in world coords, based on Spherical Mercator)
+     *
+     * @returns {void}
+     */
+    _setPosition: function () {
+        var position = this.el.getAttribute('position');
+
+        var worldCoords = this.latLonToWorld(this.currentCoords.latitude, this.currentCoords.longitude);
+
+        position.x = worldCoords[0];
+        position.z = worldCoords[1]; 
+
+        // update position
+        this.el.setAttribute('position', position);
+
+        // add the sphmerc position to the event (for testing only)
+        window.dispatchEvent(new CustomEvent('gps-camera-update-position', { detail: { position: this.currentCoords, origin: this.originCoordsProjected } }));
+    },
+    /**
+     * Returns distance in meters between camera and destination input.
+     *
+     * Assume we are using a metre-based projection. Not all 'metre-based'
+     * projections give exact metres, e.g. Spherical Mercator, but it appears 
+     * close enough to be used for AR at least in middle temperate 
+     * latitudes (40 - 55). It is heavily distorted near the poles, however.
+     *
+     * @param {Position} dest
+     * @param {Boolean} isPlace
+     *
+     * @returns {number} distance | Number.MAX_SAFE_INTEGER
+     */
+    computeDistanceMeters: function (dest, isPlace) {
+        var src = this.el.getAttribute("position");
+        var dx = dest.x - src.x;
+        var dz = dest.z - src.z;
+        var distance = Math.sqrt(dx * dx + dz * dz);
+
+        // if function has been called for a place, and if it's too near and a min distance has been set,
+        // return max distance possible - to be handled by the  method caller
+        if (isPlace && this.data.minDistance && this.data.minDistance > 0 && distance < this.data.minDistance) {
+            return Number.MAX_SAFE_INTEGER;
+        }
+
+        return distance;
+    },
+    /**
+     * Converts latitude/longitude to OpenGL world coordinates. 
+     *
+     * First projects lat/lon to absolute Spherical Mercator and then 
+     * calculates the world coordinates by comparing the Spherical Mercator
+     * coordinates with the Spherical Mercator coordinates of the origin point.
+     *
+     * @param {Number} lat 
+     * @param {Number} lon 
+     *
+     * @returns {array} world coordinates 
+     */
+    latLonToWorld: function(lat, lon) {
+        var projected = this._project (lat, lon);
+        // Sign of z needs to be reversed compared to projected coordinates
+        return [ projected[0] - this.originCoordsProjected[0], -(projected[1] - this.originCoordsProjected[1]) ];
+    },
+    /**
+     * Converts latitude/longitude to Spherical Mercator coordinates. 
+     * Algorithm is used in several OpenStreetMap-related applications.
+     *
+     * @param {Number} lat 
+     * @param {Number} lon 
+     *
+     * @returns {array} Spherical Mercator coordinates 
+     */
+    _project: function (lat, lon) {
+        const HALF_EARTH = 20037508.34;
+
+        // Convert the supplied coords to Spherical Mercator (EPSG:3857), also
+        // known as 'Google Projection', using the algorithm used extensively 
+        // in various OpenStreetMap software.
+        var y = Math.log(Math.tan((90 + lat) * Math.PI / 360.0)) / (Math.PI / 180.0);
+        return [ (lon / 180.0) * HALF_EARTH, y * HALF_EARTH / 180.0 ];
+    },
+    /**
+     * Converts Spherical Mercator coordinates to latitude/longitude.
+     * Algorithm is used in several OpenStreetMap-related applications.
+     *
+     * @param {Number} spherical mercator easting 
+     * @param {Number} spherical mercator northing 
+     *
+     * @returns {object} lon/lat
+     */
+    _unproject: function (e, n) {
+        const HALF_EARTH = 20037508.34;
+        var yp = (n / HALF_EARTH) * 180.0;
+        return { 
+            longitude: (e / HALF_EARTH) * 180.0,
+            latitude: 180.0 / Math.PI * (2 * Math.atan(Math.exp(yp * Math.PI / 180.0)) - Math.PI / 2)
+        };
+    },
+    /**
+     * Compute compass heading.
+     *
+     * @param {number} alpha
+     * @param {number} beta
+     * @param {number} gamma
+     *
+     * @returns {number} compass heading
+     */
+    _computeCompassHeading: function (alpha, beta, gamma) {
+
+        // Convert degrees to radians
+        var alphaRad = alpha * (Math.PI / 180);
+        var betaRad = beta * (Math.PI / 180);
+        var gammaRad = gamma * (Math.PI / 180);
+
+        // Calculate equation components
+        var cA = Math.cos(alphaRad);
+        var sA = Math.sin(alphaRad);
+        var sB = Math.sin(betaRad);
+        var cG = Math.cos(gammaRad);
+        var sG = Math.sin(gammaRad);
+
+        // Calculate A, B, C rotation components
+        var rA = - cA * sG - sA * sB * cG;
+        var rB = - sA * sG + cA * sB * cG;
+
+        // Calculate compass heading
+        var compassHeading = Math.atan(rA / rB);
+
+        // Convert from half unit circle to whole unit circle
+        if (rB < 0) {
+            compassHeading += Math.PI;
+        } else if (rA < 0) {
+            compassHeading += 2 * Math.PI;
+        }
+
+        // Convert radians to degrees
+        compassHeading *= 180 / Math.PI;
+
+        return compassHeading;
+    },
+
+    /**
+     * Handler for device orientation event.
+     *
+     * @param {Event} event
+     * @returns {void}
+     */
+    _onDeviceOrientation: function (event) {
+        if (event.webkitCompassHeading !== undefined) {
+            if (event.webkitCompassAccuracy < 50) {
+                this.heading = event.webkitCompassHeading;
+            } else {
+                console.warn('webkitCompassAccuracy is event.webkitCompassAccuracy');
+            }
+        } else if (event.alpha !== null) {
+            if (event.absolute === true || event.absolute === undefined) {
+                this.heading = this._computeCompassHeading(event.alpha, event.beta, event.gamma);
+            } else {
+                console.warn('event.absolute === false');
+            }
+        } else {
+            console.warn('event.alpha === null');
+        }
+    },
+
+    /**
+     * Update user rotation data.
+     *
+     * @returns {void}
+     */
+    _updateRotation: function () {
+        var heading = 360 - this.heading;
+        var cameraRotation = this.el.getAttribute('rotation').y;
+        var yawRotation = THREE.Math.radToDeg(this.lookControls.yawObject.rotation.y);
+        var offset = (heading - (cameraRotation - yawRotation)) % 360;
+        this.lookControls.yawObject.rotation.y = THREE.Math.degToRad(offset);
+    },
+});
+/** gps-projected-entity-place
+ *
+ * based on the original gps-entity-place, modified by nickw 02/04/20
+ *
+ * Rather than keeping track of position by calculating the distance of
+ * entities or the current location to the original location, this version
+ * makes use of the "Google" Spherical Mercactor projection, aka epsg:3857.
+ *
+ * The original location on startup (lat/lon) is projected into Spherical 
+ * Mercator and stored.
+ *
+ * When 'entity-places' are added, their Spherical Mercator coords are 
+ * calculated and converted into world coordinates, relative to the original
+ * position, using the Spherical Mercator projection calculation in
+ * gps-projected-camera.
+ *
+ * Spherical Mercator units are close to, but not exactly, metres, and are
+ * heavily distorted near the poles. Nonetheless they are a good approximation
+ * for many areas of the world and appear not to cause unacceptable distortions
+ * when used as the units for AR apps.
+ */
+AFRAME.registerComponent('gps-projected-entity-place', {
+    _cameraGps: null,
+    schema: {
+        longitude: {
+            type: 'number',
+            default: 0,
+        },
+        latitude: {
+            type: 'number',
+            default: 0,
+        }
+    },
+    remove: function() {
+        // cleaning listeners when the entity is removed from the DOM
+        window.removeEventListener('gps-camera-update-position', this.updatePositionListener);
+    },
+    init: function() {
+        // Used now to get the GPS camera when it's been setup
+        this.coordSetListener = () => {
+            if (!this._cameraGps) {
+                var camera = document.querySelector('[gps-projected-camera]');
+                if (!camera.components['gps-projected-camera']) {
+                    console.error('gps-projected-camera not initialized')
+                    return;
+                }
+                this._cameraGps = camera.components['gps-projected-camera'];
+                this._updatePosition();
+            }
+        };
+        
+
+
+        // update position needs to worry about distance but nothing else?
+        this.updatePositionListener = (ev) => {
+            if (!this.data || !this._cameraGps) {
+                return;
+            }
+
+            var dstCoords = this.el.getAttribute('position');
+
+            // it's actually a 'distance place', but we don't call it with last param, because we want to retrieve distance even if it's < minDistance property
+            // _computeDistanceMeters is now going to use the projected
+            var distanceForMsg = this._cameraGps.computeDistanceMeters(dstCoords);
+
+            this.el.setAttribute('distance', distanceForMsg);
+            this.el.setAttribute('distanceMsg', formatDistance(distanceForMsg));
+
+            this.el.dispatchEvent(new CustomEvent('gps-entity-place-update-positon', { detail: { distance: distanceForMsg } }));
+
+            var actualDistance = this._cameraGps.computeDistanceMeters(dstCoords, true);
+
+            if (actualDistance === Number.MAX_SAFE_INTEGER) {
+                this.hideForMinDistance(this.el, true);
+            } else {
+                this.hideForMinDistance(this.el, false);
+            }
+        };
+
+        // Retain as this event is fired when the GPS camera is set up
+        window.addEventListener('gps-camera-origin-coord-set', this.coordSetListener);
+        window.addEventListener('gps-camera-update-position', this.updatePositionListener);
+
+        this._positionXDebug = 0;
+
+        window.dispatchEvent(new CustomEvent('gps-entity-place-added', { detail: { component: this.el } }));
+    },
+    /**
+     * Hide entity according to minDistance property
+     * @returns {void}
+     */
+    hideForMinDistance: function(el, hideEntity) {
+        if (hideEntity) {
+            el.setAttribute('visible', 'false');
+        } else {
+            el.setAttribute('visible', 'true');
+        }
+    },
+    /**
+     * Update place position
+     * @returns {void}
+     */
+
+    // set position to world coords using the lat/lon 
+    _updatePosition: function() {
+        var worldPos = this._cameraGps.latLonToWorld(this.data.latitude, this.data.longitude);
+        var position = this.el.getAttribute('position');
+
+        // update element's position in 3D world
+        //this.el.setAttribute('position', position);
+        this.el.setAttribute('position', {
+            x: worldPos[0],
+            y: position.y, 
+            z: worldPos[1]
+        }); 
+    },
+});
+
+/**
+ * Format distances string
+ *
+ * @param {String} distance
+ */
+function formatDistance(distance) {
+    distance = distance.toFixed(0);
+
+    if (distance >= 1000) {
+        return (distance / 1000) + ' kilometers';
+    }
+
+    return distance + ' meters';
+};

--- a/aframe/build/aframe-ar-location-only.js
+++ b/aframe/build/aframe-ar-location-only.js
@@ -17,9 +17,7 @@ AFRAME.registerComponent('arjs-webcam-texture', {
         this.texScene.add(mesh);
         if(navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
             const constraints = { video: {
-                width: 1280,
-                height: 720,
-                facingMode: 'user' }
+                facingMode: 'environment' }
             };
             navigator.mediaDevices.getUserMedia(constraints).then( stream=> {
                 video.srcObject = stream;    

--- a/aframe/examples/location-based/arjs-webcam-texture/index.html
+++ b/aframe/examples/location-based/arjs-webcam-texture/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<meta charset="utf-8" />
+<title>Hikar Webapp</title>
+<script src="https://aframe.io/releases/1.0.4/aframe.min.js"></script>
+<script src="https://unpkg.com/aframe-look-at-component@0.8.0/dist/aframe-look-at-component.min.js"></script>
+<script src="../../..//build/aframe-ar-nft.js"></script>
+<link rel='stylesheet' type='text/css' href='css/webapp.css' />
+</head>
+
+<body>
+    <a-scene vr-mode-ui="enabled: false" renderer='antialias: true; alpha:true' arjs='videoTexture: true; sourceType: webcam; debugUIEnabled: false'>
+        <a-camera id='camera1' near="0.1" far="50000" fov="80" gps-camera='simulateLatitude: 51.049; simulateLongitude: -0.723' rotation-reader vertical-controls wasd-controls="acceleration: 1300">
+        </a-camera>
+
+        <!-- This is perhaps 1.5 kilometres from the starting point.
+             With videoTexture: false it does not appear. 
+             With videoTexture: true, it does. -->
+        <a-box gps-entity-place='latitude: 51.0597; longitude: -0.7171' material='color: yellow' position='0 90 0' scale='100 100 100'></a-box>
+    </a-scene>
+</body>
+
+</html>

--- a/aframe/src/location-based/arjs-webcam-texture.js
+++ b/aframe/src/location-based/arjs-webcam-texture.js
@@ -17,9 +17,7 @@ AFRAME.registerComponent('arjs-webcam-texture', {
         this.texScene.add(mesh);
         if(navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
             const constraints = { video: {
-                width: 1280,
-                height: 720,
-                facingMode: 'user' }
+                facingMode: 'environment' }
             };
             navigator.mediaDevices.getUserMedia(constraints).then( stream=> {
                 video.srcObject = stream;    

--- a/aframe/src/location-based/arjs-webcam-texture.js
+++ b/aframe/src/location-based/arjs-webcam-texture.js
@@ -1,0 +1,39 @@
+AFRAME.registerComponent('arjs-webcam-texture', {
+
+    init: function() {
+        this.scene = this.el.sceneEl;
+        this.texCamera = new THREE.OrthographicCamera(-0.5, 0.5, 0.5, -0.5, 0, 10);
+        this.texScene = new THREE.Scene();
+
+        this.scene.renderer.autoClear = false;
+        const video = document.createElement("video");
+        video.setAttribute("autoplay", true);
+        video.setAttribute("display", "none");
+        document.body.appendChild(video);
+        const geom = new THREE.PlaneBufferGeometry(); //0.5, 0.5);
+        const texture = new THREE.VideoTexture(video);
+        const material = new THREE.MeshBasicMaterial( { map: texture } );
+        const mesh = new THREE.Mesh(geom, material);
+        this.texScene.add(mesh);
+        if(navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
+            const constraints = { video: {
+                width: 1280,
+                height: 720,
+                facingMode: 'user' }
+            };
+            navigator.mediaDevices.getUserMedia(constraints).then( stream=> {
+                video.srcObject = stream;    
+                video.play();
+            })
+            .catch(e => { alert(`Webcam error: ${e}`); });
+        } else {
+            alert('sorry - media devices API not supported');
+        }
+    },
+
+    tick: function() {
+        this.scene.renderer.clear();
+        this.scene.renderer.render(this.texScene, this.texCamera);
+        this.scene.renderer.clearDepth();
+    }
+});

--- a/aframe/src/system-arjs.js
+++ b/aframe/src/system-arjs.js
@@ -20,6 +20,11 @@ AFRAME.registerSystem('arjs', {
             type: 'string',
             default: '',
         },
+        // new video texture mode (location based only)
+        videoTexture: {
+            type: 'boolean',
+            default: false
+        },
         // old parameters
         debug: {
             type: 'boolean',
@@ -90,6 +95,13 @@ AFRAME.registerSystem('arjs', {
     init: function () {
         var _this = this
 
+        // If videoTexture is set, skip the remainder of the setup entirely and just use the arjs-webcam-texture component
+        if(this.data.videoTexture === true && this.data.sourceType === 'webcam') {
+            var webcamEntity = document.createElement("a-entity");
+            webcamEntity.setAttribute("arjs-webcam-texture", true);
+            this.el.sceneEl.appendChild(webcamEntity);
+            return;
+        } 
         //////////////////////////////////////////////////////////////////////////////
         //		setup arProfile
         //////////////////////////////////////////////////////////////////////////////
@@ -214,7 +226,7 @@ AFRAME.registerSystem('arjs', {
 
     tick: function () {
         // skip it if not yet isInitialised
-        if (this.isReady === false) return
+        if (this.isReady === false || this.data.videoTexture === true) return
 
         // update arSession
         this._arSession.update()


### PR DESCRIPTION
<!-- Please, don't delete this template or we'll close your issue -->

**⚠️ All PRs have to be done versus 'dev' branch, so be aware of that, or we'll close your issue ⚠️**

**What kind of change does this PR introduce?**
<!-- Can be a new feature, a bugfix, or refactoring, etc -->
Partial fix of issue #110. Allows AR content distant from the current position to be viewed, up to the far clip plane.

**Can it be referenced to an Issue? If so what is the issue # ?**
#110 

**How can we test it?**
<!-- All information can be found about our tests in https://github.com/jeromeetienne/AR.js/blob/master/test/TODO.md -->
<!-- At the moment we don't explicitly require tests, because it's not streamlined yet -->
Use test application at
https://hikar.org/webapp/

On a mobile device, will use GPS location. Or, on a desktop, use hardcoded location:
https://hikar.org/webapp/?lat=51.049&lon=-0.723

Ensure you hard-refresh your browser, to make sure you're not using an earlier version without this feature.
**Summary**
<!-- State here what problem the PR solves and what is the proposed solution -->
Camera feed is rendered using a WebGL texture, making use of `THREE.VideoTexture` within an A-Frame component.

**Does this PR introduce a breaking change?**
No

**Please TEST your PR before proposing it. Specify here what device you have used for tests, version of OS and version of Browser**
Laptop using Ubuntu 18.04 and latest versions of Firefox and Chrome; Pixel 3 running Android 10 and again latest versions of Firefox and Chrome.

**Other information**
Some detail about this along with the current shortcomings and flaws. I'd like to invite discussion on whether this PR fits in with the overall AR.js architecture.

First of all I have created a new A-Frame component, `arjs-webcam-texture`, within the aframe/src/location-based directory. This will use `THREE.VideoTexture` to stream the webcam video to a texture.

I've had to do a bit of a hack to do this; I first attempted it using pure three.js and then within the `arjs-webcam-texture` A-Frame component. Namely, a second camera, an `OrthographicCamera` (as we don't want perspective for the texture) is created, and then a geometry is created to fill the whole screen.
A mesh is created using this geometry and the texture, and attached to a *separate* scene. (I'm not sure whether you can have one scene with two entirely separate cameras for completely different purposes).

Then in the component's `tick()`, this separate scene is rendered using the orthographic camera. This appears to be the recommended way of doing this in plain three.js, and it appears to work in A-Frame also. Some parameters need to be set to prevent the screen clearing between rendering the two scenes.

The other change is that in the `arjs-system`, a new property `videoTexture` is added. If this is true, then the new `arjs-webcam-texture` component is used (by dynamically creating a new `a-entity` using it and attaching it to the scene), and the existing `ARjs.Session` is not used at all.

This basically works, but with one main flaw, the field of view of the AR view does not match that of the hardware camera device. Actually, looking quickly through the AR.js source code, there does not appear to be anything there yet which obtains the FOV of the hardware camera device, is this correct?

I believe this is an issue with the augmented content, not the live camera stream, as the FOV of the live camera stream appears to match that of the native camera app of the mobile device (Pixel 3) used to test.

Would like to get feedback on this PR and whether my proposed approach fits in with the long-term plans of AR.js and in particular, how compatible this is with the NFT feature and any future image detection functionality.
