### PR TITLE
Changed mistake in source code where the minConfidence property was not registering

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,6 @@ Please follow this simple steps:
 
 ```html
 <!DOCTYPE html>
-<!DOCTYPE html>
 <html>
     <script src="https://aframe.io/releases/1.0.0/aframe.min.js"></script>
     <!-- we import arjs version without NFT but with marker + location based support -->

--- a/aframe/build/aframe-ar-nft.js
+++ b/aframe/build/aframe-ar-nft.js
@@ -823,7 +823,7 @@ function process() {
 
 function onMarkerFound(event) {
     if (event.data.type === artoolkit.PATTERN_MARKER && event.data.marker.cfPatt < _this.parameters.minConfidence) return
-    if (event.data.type === artoolkit.BARCODE_MARKER && event.data.marker.cfMatt < _this.parameters.minConfidence) return
+    if (event.data.type === artoolkit.BARCODE_MARKER && event.data.marker.cfMatrix < _this.parameters.minConfidence) return
 
     var modelViewMatrix = new THREE.Matrix4().fromArray(event.data.matrix)
     _this.updateWithModelViewMatrix(modelViewMatrix)
@@ -3711,6 +3711,7 @@ AFRAME.registerComponent('arjs-anchor', {
                 markerParameters.markersAreaEnabled = false
             }
 
+            markerParameters.minConfidence = _this.data.minConfidence;
             markerParameters.smooth = _this.data.smooth;
             markerParameters.smoothCount = _this.data.smoothCount;
             markerParameters.smoothTolerance = _this.data.smoothTolerance;

--- a/aframe/build/aframe-ar.js
+++ b/aframe/build/aframe-ar.js
@@ -2222,7 +2222,7 @@ ARjs.MarkerControls.prototype._initArtoolkit = function(){
 	function onMarkerFound(event){
 		// honor his.parameters.minConfidence
 		if( event.data.type === artoolkit.PATTERN_MARKER && event.data.marker.cfPatt < _this.parameters.minConfidence )	return
-		if( event.data.type === artoolkit.BARCODE_MARKER && event.data.marker.cfMatt < _this.parameters.minConfidence )	return
+		if( event.data.type === artoolkit.BARCODE_MARKER && event.data.marker.cfMatrix < _this.parameters.minConfidence )	return
 
 		var modelViewMatrix = new THREE.Matrix4().fromArray(event.data.matrix)
 		_this.updateWithModelViewMatrix(modelViewMatrix)
@@ -5082,7 +5082,8 @@ AFRAME.registerComponent('arjs-anchor', {
                 markerParameters.patternUrl = _this.data.patternUrl;
                 markerParameters.markersAreaEnabled = false
             }
-
+			
+			markerParameters.minConfidence = _this.data.minConfidence;
             markerParameters.smooth = _this.data.smooth;
             markerParameters.smoothCount = _this.data.smoothCount;
             markerParameters.smoothTolerance = _this.data.smoothTolerance;

--- a/aframe/src/component-anchor-nft.js
+++ b/aframe/src/component-anchor-nft.js
@@ -122,6 +122,7 @@ AFRAME.registerComponent('arjs-anchor', {
                 markerParameters.markersAreaEnabled = false
             }
 
+            markerParameters.minConfidence = _this.data.minConfidence;
             markerParameters.smooth = _this.data.smooth;
             markerParameters.smoothCount = _this.data.smoothCount;
             markerParameters.smoothTolerance = _this.data.smoothTolerance;

--- a/aframe/src/component-anchor.js
+++ b/aframe/src/component-anchor.js
@@ -115,6 +115,7 @@ AFRAME.registerComponent('arjs-anchor', {
                 markerParameters.markersAreaEnabled = false
             }
 
+            markerParameters.minConfidence = _this.data.minCondidence;
             markerParameters.smooth = _this.data.smooth;
             markerParameters.smoothCount = _this.data.smoothCount;
             markerParameters.smoothTolerance = _this.data.smoothTolerance;

--- a/three.js/src/threex/threex-armarkercontrols-nft-end.js
+++ b/three.js/src/threex/threex-armarkercontrols-nft-end.js
@@ -91,7 +91,7 @@ function process() {
 
 function onMarkerFound(event) {
     if (event.data.type === artoolkit.PATTERN_MARKER && event.data.marker.cfPatt < _this.parameters.minConfidence) return
-    if (event.data.type === artoolkit.BARCODE_MARKER && event.data.marker.cfMatt < _this.parameters.minConfidence) return
+    if (event.data.type === artoolkit.BARCODE_MARKER && event.data.marker.cfMatrix < _this.parameters.minConfidence) return
 
     var modelViewMatrix = new THREE.Matrix4().fromArray(event.data.matrix)
     _this.updateWithModelViewMatrix(modelViewMatrix)

--- a/three.js/src/threex/threex-armarkercontrols.js
+++ b/three.js/src/threex/threex-armarkercontrols.js
@@ -262,7 +262,7 @@ ARjs.MarkerControls.prototype._initArtoolkit = function(){
 	function onMarkerFound(event){
 		// honor his.parameters.minConfidence
 		if( event.data.type === artoolkit.PATTERN_MARKER && event.data.marker.cfPatt < _this.parameters.minConfidence )	return
-		if( event.data.type === artoolkit.BARCODE_MARKER && event.data.marker.cfMatt < _this.parameters.minConfidence )	return
+		if( event.data.type === artoolkit.BARCODE_MARKER && event.data.marker.cfMatrix < _this.parameters.minConfidence )	return
 
 		var modelViewMatrix = new THREE.Matrix4().fromArray(event.data.matrix)
 		_this.updateWithModelViewMatrix(modelViewMatrix)


### PR DESCRIPTION
<!-- Please, don't delete this template or we'll close your issue -->

**⚠️ All PRs have to be done versus 'dev' branch, so be aware of that, or we'll close your issue ⚠️**

**What kind of change does this PR introduce?**
Changed mistake in reference to event.data.marker.cfMatrix in ARjs.MarkerControls.
Added missing reference to _this.data.minConfidence in arjs-anchor component.

**Can it be referenced to an Issue? If so what is the issue # ?**
https://github.com/AR-js-org/AR.js/issues/127#issue-642241256

**How can we test it?**
Add the logs below to line 263 in threex-armarkercontrols.js:
console.log(event.data.marker.cfMatrix);
console.log(event.data.marker.cfMatt);  // To see that it doesn't exist
console.log(_this.parameters.minConfidence);

Follow the guide here: https://medium.com/chialab-open-source/ar-js-the-simpliest-way-to-get-cross-browser-ar-on-the-web-8f670dd45462

Then add min-confidence to a-marker, e.g.:
<a-marker type="barcode" value="4" min-confidence="0.4"></a-marker>

Lastly, watch the console log while looking at the marker.


**Summary**
There was a mistake in ARjs.MarkerControls when event.data.marker.cfMatt was used to get the current confidence level when watching a marker using matrixcode. When logging the event data you can see that this property does not exist. The correct one is event.data.marker.cfMatrix.

There was also a missing reference to the property minConfidence in the schema of 'arjs-anchor' component. So when setting the minConfidence property in an a-frame entity, it was not registered and always defaulted to 0.6. The change I added now updates minConfidence to the value set in the component in the  entity:
e.g. <a-marker min-confidence="0.4" .... >

**Does this PR introduce a breaking change?**
No.

**Please TEST your PR before proposing it. Specify here what device you have used for tests, version of OS and version of Browser**

**Other information**
