### PR TITLE
Reduce shaking of nearby objects

### DIFF
--- a/aframe/build/aframe-ar-location-only.js
+++ b/aframe/build/aframe-ar-location-only.js
@@ -35,6 +35,15 @@ AFRAME.registerComponent('arjs-webcam-texture', {
         this.scene.renderer.clearDepth();
     }
 });
+/*
+ * UPDATES 28/08/20:
+ *
+ * - add gpsMinDistance and gpsTimeInterval properties to control how 
+ * frequently GPS updates are processed. Aim is to prevent 'stuttering' 
+ * effects when close to AR content due to continuous small changes in 
+ * location.
+ */
+
 AFRAME.registerComponent('gps-camera', {
     _watchPositionId: null,
     originCoords: null,
@@ -69,6 +78,14 @@ AFRAME.registerComponent('gps-camera', {
         maxDistance: {
             type: 'int',
             default: 0,
+        },
+        gpsMinDistance: {
+            type: 'number',
+            default: 0
+        },
+        gpsTimeInterval: {
+            type: 'number',
+            default: 0
         }
     },
     update: function() {
@@ -88,6 +105,11 @@ AFRAME.registerComponent('gps-camera', {
         if (!this.el.components['look-controls']) {
             return;
         }
+ 
+        this.lastPosition = {
+            latitude: 0,
+            longitude: 0
+        };
 
         this.loader = document.createElement('DIV');
         this.loader.classList.add('arjs-loader');
@@ -141,12 +163,24 @@ AFRAME.registerComponent('gps-camera', {
                 localPosition.latitude = this.data.simulateLatitude;
                 localPosition.altitude = this.data.simulateAltitude;
                 this.currentCoords = localPosition;
+                this._updatePosition();
             }
             else {
                 this.currentCoords = position.coords;
+                var distMoved = this._haversineDist(
+                    this.lastPosition,
+                    this.currentCoords
+                );
+
+                if(distMoved >= this.data.gpsMinDistance || !this.originCoordsProjected) {
+                    this._updatePosition();
+                    this.lastPosition = {
+                        longitude: this.currentCoords.longitude,
+                        latitude: this.currentCoords.latitude
+                    }; 
+                }
             }
 
-            this._updatePosition();
         }.bind(this));
     },
 
@@ -217,7 +251,7 @@ AFRAME.registerComponent('gps-camera', {
         // https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/watchPosition
         return navigator.geolocation.watchPosition(onSuccess, onError, {
             enableHighAccuracy: true,
-            maximumAge: 0,
+            maximumAge: this.data.gpsTimeInterval,
             timeout: 27000,
         });
     },
@@ -297,12 +331,7 @@ AFRAME.registerComponent('gps-camera', {
      * @returns {number} distance | Number.MAX_SAFE_INTEGER
      */
     computeDistanceMeters: function (src, dest, isPlace) {
-        var dlongitude = THREE.Math.degToRad(dest.longitude - src.longitude);
-        var dlatitude = THREE.Math.degToRad(dest.latitude - src.latitude);
-
-        var a = (Math.sin(dlatitude / 2) * Math.sin(dlatitude / 2)) + Math.cos(THREE.Math.degToRad(src.latitude)) * Math.cos(THREE.Math.degToRad(dest.latitude)) * (Math.sin(dlongitude / 2) * Math.sin(dlongitude / 2));
-        var angle = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-        var distance = angle * 6378160;
+        var distance = this._haversineDist (src, dest);
 
         // if function has been called for a place, and if it's too near and a min distance has been set,
         // return max distance possible - to be handled by the caller
@@ -317,6 +346,15 @@ AFRAME.registerComponent('gps-camera', {
         }
 
         return distance;
+    },
+
+    _haversineDist: function (src, dest) {
+        var dlongitude = THREE.Math.degToRad(dest.longitude - src.longitude);
+        var dlatitude = THREE.Math.degToRad(dest.latitude - src.latitude);
+
+        var a = (Math.sin(dlatitude / 2) * Math.sin(dlatitude / 2)) + Math.cos(THREE.Math.degToRad(src.latitude)) * Math.cos(THREE.Math.degToRad(dest.latitude)) * (Math.sin(dlongitude / 2) * Math.sin(dlongitude / 2));
+        var angle = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return angle * 6371000;
     },
 
     /**
@@ -548,6 +586,13 @@ function formatDistance(distance) {
  * heavily distorted near the poles. Nonetheless they are a good approximation
  * for many areas of the world and appear not to cause unacceptable distortions
  * when used as the units for AR apps.
+ *
+ * UPDATES 28/08/20:
+ *
+ * - add gpsMinDistance and gpsTimeInterval properties to control how 
+ * frequently GPS updates are processed. Aim is to prevent 'stuttering' 
+ * effects when close to AR content due to continuous small changes in 
+ * location.
  */
 
 AFRAME.registerComponent('gps-projected-camera', {
@@ -580,6 +625,14 @@ AFRAME.registerComponent('gps-projected-camera', {
         minDistance: {
             type: 'int',
             default: 0,
+        },
+        gpsMinDistance: {
+            type: 'number',
+            default: 0
+        },
+        gpsTimeInterval: {
+            type: 'number',
+            default: 0
         }
     },
     update: function() {
@@ -599,6 +652,11 @@ AFRAME.registerComponent('gps-projected-camera', {
         if (!this.el.components['look-controls']) {
             return;
         }
+
+        this.lastPosition = {
+            latitude: 0,
+            longitude: 0 
+        };
 
         this.loader = document.createElement('DIV');
         this.loader.classList.add('arjs-loader');
@@ -652,12 +710,25 @@ AFRAME.registerComponent('gps-projected-camera', {
                 localPosition.latitude = this.data.simulateLatitude;
                 localPosition.altitude = this.data.simulateAltitude;
                 this.currentCoords = localPosition;
+                this._updatePosition();
             }
             else {
                 this.currentCoords = position.coords;
+
+                var distMoved = this._haversineDist(
+                    this.lastPosition,
+                    this.currentCoords
+                );
+
+                if(distMoved >= this.data.gpsMinDistance || !this.originCoordsProjected) {
+                    this._updatePosition();
+                    this.lastPosition = {
+                        longitude: this.currentCoords.longitude,
+                        latitude: this.currentCoords.latitude
+                    }; 
+                }
             }
 
-            this._updatePosition();
         }.bind(this));
     },
 
@@ -728,7 +799,7 @@ AFRAME.registerComponent('gps-projected-camera', {
         // https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/watchPosition
         return navigator.geolocation.watchPosition(onSuccess, onError, {
             enableHighAccuracy: true,
-            maximumAge: 0,
+            maximumAge: this.data.gpsTimeInterval,
             timeout: 27000,
         });
     },
@@ -948,6 +1019,20 @@ AFRAME.registerComponent('gps-projected-camera', {
         var offset = (heading - (cameraRotation - yawRotation)) % 360;
         this.lookControls.yawObject.rotation.y = THREE.Math.degToRad(offset);
     },
+
+    /**
+     * Calculate haversine distance between two lat/lon pairs.
+     *
+     * Taken from gps-camera 
+     */
+    _haversineDist: function (src, dest) {
+        var dlongitude = THREE.Math.degToRad(dest.longitude - src.longitude);
+        var dlatitude = THREE.Math.degToRad(dest.latitude - src.latitude);
+
+        var a = (Math.sin(dlatitude / 2) * Math.sin(dlatitude / 2)) + Math.cos(THREE.Math.degToRad(src.latitude)) * Math.cos(THREE.Math.degToRad(dest.latitude)) * (Math.sin(dlongitude / 2) * Math.sin(dlongitude / 2));
+        var angle = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return angle * 6371000;
+    }
 });
 /** gps-projected-entity-place
  *

--- a/aframe/build/aframe-ar-location-only.js
+++ b/aframe/build/aframe-ar-location-only.js
@@ -86,6 +86,10 @@ AFRAME.registerComponent('gps-camera', {
         gpsTimeInterval: {
             type: 'number',
             default: 0
+        },
+        accelerationToMove: {
+            type: 'number',
+            default: 0
         }
     },
     update: function() {
@@ -110,6 +114,17 @@ AFRAME.registerComponent('gps-camera', {
             latitude: 0,
             longitude: 0
         };
+
+        this.maxAcceleration = 0;
+        window.addEventListener('devicemotion', e => {
+            if(e.acceleration) {
+                this.maxAcceleration = Math.max (
+                    Math.abs(e.acceleration.x),
+                    Math.abs(e.acceleration.y),
+                    Math.abs(e.acceleration.z)
+                );
+            }
+        });
 
         this.loader = document.createElement('DIV');
         this.loader.classList.add('arjs-loader');
@@ -172,7 +187,7 @@ AFRAME.registerComponent('gps-camera', {
                     this.currentCoords
                 );
 
-                if(distMoved >= this.data.gpsMinDistance || !this.originCoordsProjected) {
+                if((distMoved >= this.data.gpsMinDistance && this.maxAcceleration >= this.data.accelerationToMove) || !this.originCoordsProjected) {
                     this._updatePosition();
                     this.lastPosition = {
                         longitude: this.currentCoords.longitude,
@@ -633,6 +648,10 @@ AFRAME.registerComponent('gps-projected-camera', {
         gpsTimeInterval: {
             type: 'number',
             default: 0
+        },
+        accelerationToMove: {
+            type: 'number',
+            default: 0
         }
     },
     update: function() {
@@ -657,6 +676,17 @@ AFRAME.registerComponent('gps-projected-camera', {
             latitude: 0,
             longitude: 0 
         };
+
+        this.maxAcceleration = 0;
+        window.addEventListener('devicemotion', e => {
+            if(e.acceleration) {
+                this.maxAcceleration = Math.max (
+                    Math.abs(e.acceleration.x),
+                    Math.abs(e.acceleration.y),
+                    Math.abs(e.acceleration.z)
+                );
+            }
+        });
 
         this.loader = document.createElement('DIV');
         this.loader.classList.add('arjs-loader');
@@ -720,7 +750,7 @@ AFRAME.registerComponent('gps-projected-camera', {
                     this.currentCoords
                 );
 
-                if(distMoved >= this.data.gpsMinDistance || !this.originCoordsProjected) {
+                if((distMoved >= this.data.gpsMinDistance && this.maxAcceleration >= this.data.accelerationToMove) || !this.originCoordsProjected) {
                     this._updatePosition();
                     this.lastPosition = {
                         longitude: this.currentCoords.longitude,

--- a/aframe/build/aframe-ar-nft.js
+++ b/aframe/build/aframe-ar-nft.js
@@ -4050,6 +4050,10 @@ AFRAME.registerComponent('gps-camera', {
         gpsTimeInterval: {
             type: 'number',
             default: 0
+        },
+        accelerationToMove: {
+            type: 'number',
+            default: 0
         }
     },
     update: function() {
@@ -4074,6 +4078,17 @@ AFRAME.registerComponent('gps-camera', {
             latitude: 0,
             longitude: 0
         };
+
+        this.maxAcceleration = 0;
+        window.addEventListener('devicemotion', e => {
+            if(e.acceleration) {
+                this.maxAcceleration = Math.max (
+                    Math.abs(e.acceleration.x),
+                    Math.abs(e.acceleration.y),
+                    Math.abs(e.acceleration.z)
+                );
+            }
+        });
 
         this.loader = document.createElement('DIV');
         this.loader.classList.add('arjs-loader');
@@ -4136,7 +4151,7 @@ AFRAME.registerComponent('gps-camera', {
                     this.currentCoords
                 );
 
-                if(distMoved >= this.data.gpsMinDistance || !this.originCoordsProjected) {
+                if((distMoved >= this.data.gpsMinDistance && this.maxAcceleration >= this.data.accelerationToMove) || !this.originCoordsProjected) {
                     this._updatePosition();
                     this.lastPosition = {
                         longitude: this.currentCoords.longitude,
@@ -4597,6 +4612,10 @@ AFRAME.registerComponent('gps-projected-camera', {
         gpsTimeInterval: {
             type: 'number',
             default: 0
+        },
+        accelerationToMove: {
+            type: 'number',
+            default: 0
         }
     },
     update: function() {
@@ -4621,6 +4640,17 @@ AFRAME.registerComponent('gps-projected-camera', {
             latitude: 0,
             longitude: 0 
         };
+
+        this.maxAcceleration = 0;
+        window.addEventListener('devicemotion', e => {
+            if(e.acceleration) {
+                this.maxAcceleration = Math.max (
+                    Math.abs(e.acceleration.x),
+                    Math.abs(e.acceleration.y),
+                    Math.abs(e.acceleration.z)
+                );
+            }
+        });
 
         this.loader = document.createElement('DIV');
         this.loader.classList.add('arjs-loader');
@@ -4684,7 +4714,7 @@ AFRAME.registerComponent('gps-projected-camera', {
                     this.currentCoords
                 );
 
-                if(distMoved >= this.data.gpsMinDistance || !this.originCoordsProjected) {
+                if((distMoved >= this.data.gpsMinDistance && this.maxAcceleration >= this.data.accelerationToMove) || !this.originCoordsProjected) {
                     this._updatePosition();
                     this.lastPosition = {
                         longitude: this.currentCoords.longitude,

--- a/aframe/src/location-based/gps-camera.js
+++ b/aframe/src/location-based/gps-camera.js
@@ -49,6 +49,10 @@ AFRAME.registerComponent('gps-camera', {
         gpsTimeInterval: {
             type: 'number',
             default: 0
+        },
+        accelerationToMove: {
+            type: 'number',
+            default: 0
         }
     },
     update: function() {
@@ -73,6 +77,17 @@ AFRAME.registerComponent('gps-camera', {
             latitude: 0,
             longitude: 0
         };
+
+        this.maxAcceleration = 0;
+        window.addEventListener('devicemotion', e => {
+            if(e.acceleration) {
+                this.maxAcceleration = Math.max (
+                    Math.abs(e.acceleration.x),
+                    Math.abs(e.acceleration.y),
+                    Math.abs(e.acceleration.z)
+                );
+            }
+        });
 
         this.loader = document.createElement('DIV');
         this.loader.classList.add('arjs-loader');
@@ -135,7 +150,7 @@ AFRAME.registerComponent('gps-camera', {
                     this.currentCoords
                 );
 
-                if(distMoved >= this.data.gpsMinDistance || !this.originCoordsProjected) {
+                if((distMoved >= this.data.gpsMinDistance && this.maxAcceleration >= this.data.accelerationToMove) || !this.originCoordsProjected) {
                     this._updatePosition();
                     this.lastPosition = {
                         longitude: this.currentCoords.longitude,

--- a/aframe/src/location-based/gps-projected-camera.js
+++ b/aframe/src/location-based/gps-projected-camera.js
@@ -20,6 +20,13 @@
  * heavily distorted near the poles. Nonetheless they are a good approximation
  * for many areas of the world and appear not to cause unacceptable distortions
  * when used as the units for AR apps.
+ *
+ * UPDATES 28/08/20:
+ *
+ * - add gpsMinDistance and gpsTimeInterval properties to control how 
+ * frequently GPS updates are processed. Aim is to prevent 'stuttering' 
+ * effects when close to AR content due to continuous small changes in 
+ * location.
  */
 
 AFRAME.registerComponent('gps-projected-camera', {
@@ -52,6 +59,14 @@ AFRAME.registerComponent('gps-projected-camera', {
         minDistance: {
             type: 'int',
             default: 0,
+        },
+        gpsMinDistance: {
+            type: 'number',
+            default: 0
+        },
+        gpsTimeInterval: {
+            type: 'number',
+            default: 0
         }
     },
     update: function() {
@@ -71,6 +86,11 @@ AFRAME.registerComponent('gps-projected-camera', {
         if (!this.el.components['look-controls']) {
             return;
         }
+
+        this.lastPosition = {
+            latitude: 0,
+            longitude: 0 
+        };
 
         this.loader = document.createElement('DIV');
         this.loader.classList.add('arjs-loader');
@@ -124,12 +144,25 @@ AFRAME.registerComponent('gps-projected-camera', {
                 localPosition.latitude = this.data.simulateLatitude;
                 localPosition.altitude = this.data.simulateAltitude;
                 this.currentCoords = localPosition;
+                this._updatePosition();
             }
             else {
                 this.currentCoords = position.coords;
+
+                var distMoved = this._haversineDist(
+                    this.lastPosition,
+                    this.currentCoords
+                );
+
+                if(distMoved >= this.data.gpsMinDistance || !this.originCoordsProjected) {
+                    this._updatePosition();
+                    this.lastPosition = {
+                        longitude: this.currentCoords.longitude,
+                        latitude: this.currentCoords.latitude
+                    }; 
+                }
             }
 
-            this._updatePosition();
         }.bind(this));
     },
 
@@ -200,7 +233,7 @@ AFRAME.registerComponent('gps-projected-camera', {
         // https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/watchPosition
         return navigator.geolocation.watchPosition(onSuccess, onError, {
             enableHighAccuracy: true,
-            maximumAge: 0,
+            maximumAge: this.data.gpsTimeInterval,
             timeout: 27000,
         });
     },
@@ -420,4 +453,18 @@ AFRAME.registerComponent('gps-projected-camera', {
         var offset = (heading - (cameraRotation - yawRotation)) % 360;
         this.lookControls.yawObject.rotation.y = THREE.Math.degToRad(offset);
     },
+
+    /**
+     * Calculate haversine distance between two lat/lon pairs.
+     *
+     * Taken from gps-camera 
+     */
+    _haversineDist: function (src, dest) {
+        var dlongitude = THREE.Math.degToRad(dest.longitude - src.longitude);
+        var dlatitude = THREE.Math.degToRad(dest.latitude - src.latitude);
+
+        var a = (Math.sin(dlatitude / 2) * Math.sin(dlatitude / 2)) + Math.cos(THREE.Math.degToRad(src.latitude)) * Math.cos(THREE.Math.degToRad(dest.latitude)) * (Math.sin(dlongitude / 2) * Math.sin(dlongitude / 2));
+        var angle = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return angle * 6371000;
+    }
 });

--- a/aframe/src/location-based/gps-projected-camera.js
+++ b/aframe/src/location-based/gps-projected-camera.js
@@ -67,6 +67,10 @@ AFRAME.registerComponent('gps-projected-camera', {
         gpsTimeInterval: {
             type: 'number',
             default: 0
+        },
+        accelerationToMove: {
+            type: 'number',
+            default: 0
         }
     },
     update: function() {
@@ -91,6 +95,17 @@ AFRAME.registerComponent('gps-projected-camera', {
             latitude: 0,
             longitude: 0 
         };
+
+        this.maxAcceleration = 0;
+        window.addEventListener('devicemotion', e => {
+            if(e.acceleration) {
+                this.maxAcceleration = Math.max (
+                    Math.abs(e.acceleration.x),
+                    Math.abs(e.acceleration.y),
+                    Math.abs(e.acceleration.z)
+                );
+            }
+        });
 
         this.loader = document.createElement('DIV');
         this.loader.classList.add('arjs-loader');
@@ -154,7 +169,7 @@ AFRAME.registerComponent('gps-projected-camera', {
                     this.currentCoords
                 );
 
-                if(distMoved >= this.data.gpsMinDistance || !this.originCoordsProjected) {
+                if((distMoved >= this.data.gpsMinDistance && this.maxAcceleration >= this.data.accelerationToMove) || !this.originCoordsProjected) {
                     this._updatePosition();
                     this.lastPosition = {
                         longitude: this.currentCoords.longitude,


### PR DESCRIPTION
<!-- Please, don't delete this template or we'll close your issue -->

**⚠️ All PRs have to be done versus 'dev' branch, so be aware of that, or we'll close your issue ⚠️**

**What kind of change does this PR introduce?**
<!-- Can be a new feature, a bugfix, or refactoring, etc -->
Enhance `gps-camera` and `gps-projected-camera` to allow specification of `gpsMinDistance` and `gpsTimeInterval` properties to restrict GPS updates to every so-many metres or milliseconds. `gpsMinDistance` is probably the most useful. That can be used to help reduce 'shaking' when you are near to a model or other AR content, as the A-Frame camera will only change position if you have moved so-many metres. I found 5 metres is a good value to use, though the default is still 0.

Note the `gpsTimeInterval` works by setting the `maximumAge` option when calling `watchPosition`. It does not try to do its own time measurement.

Also add a more experimental `accelerationToMove` property. If the device motion API is available, this can be used to prevent GPS updates if the maximum acceleration (without effect of gravity) in the three x, y and z axes is below a certain threshold in m/s/s. On my device I found that if it is still, then generally the maximum acceleration is no more than 1.0 m/s/s. The aim is to try and 'sense' when the device is still, and prevent GPS updates when the device is still, again to avoid the 'shaking' effect.

This is more experimental than the above, as it probably needs testing on a wide range of devices with sensors of different accuracy and sensitivity; nonetheless the option is there if people want to play with it.

**Can it be referenced to an Issue? If so what is the issue # ?**

**How can we test it?**
<!-- All information can be found about our tests in https://github.com/jeromeetienne/AR.js/blob/master/test/TODO.md -->
<!-- At the moment we don't explicitly require tests, because it's not streamlined yet -->
Use any of the examples with the modified code, and add the appropriate property to the `gps-camera` or `gps-projected-camera` component.

**Summary**
<!-- State here what problem the PR solves and what is the proposed solution -->
Reducing shaking of nearby objects due to frequent small changes in GPS position.

**Does this PR introduce a breaking change?**
No, though I have corrected the Earth's radius in the haversine distance formula to 6371000 metres,

**Please TEST your PR before proposing it. Specify here what device you have used for tests, version of OS and version of Browser**
Pixel 3 and Chrome latest.

**Other information**
