### PR TITLE
Custom arjs-look-controls component and smoothing to reduce shaking effect

### DIFF
--- a/aframe/build/aframe-ar-location-only.js
+++ b/aframe/build/aframe-ar-location-only.js
@@ -753,7 +753,7 @@ AFRAME.registerComponent('gps-camera', {
         }
     },
     init: function () {
-        if (!this.el.components['arjs-look-controls']) {
+        if (!this.el.components['arjs-look-controls'] && !this.el.components['look-controls']) {
             return;
         }
 
@@ -776,7 +776,7 @@ AFRAME.registerComponent('gps-camera', {
             }
         }.bind(this));
 
-        this.lookControls = this.el.components['arjs-look-controls'];
+        this.lookControls = this.el.components['arjs-look-controls'] || this.el.components['look-controls'];
 
         // listen to deviceorientation event
         var eventName = this._getDeviceOrientationEventName();
@@ -1300,7 +1300,7 @@ AFRAME.registerComponent('gps-projected-camera', {
         }
     },
     init: function() {
-        if (!this.el.components['arjs-look-controls']) {
+        if (!this.el.components['arjs-look-controls'] && !this.el.components['look-controls']) {
             return;
         }
 
@@ -1323,7 +1323,7 @@ AFRAME.registerComponent('gps-projected-camera', {
             }
         }.bind(this));
 
-        this.lookControls = this.el.components['arjs-look-controls'];
+        this.lookControls = this.el.components['arjs-look-controls'] || this.el.components['look-controls'];
 
         // listen to deviceorientation event
         var eventName = this._getDeviceOrientationEventName();

--- a/aframe/build/aframe-ar-location-only.js
+++ b/aframe/build/aframe-ar-location-only.js
@@ -1,3 +1,654 @@
+/**
+ * @author richt / http://richt.me
+ * @author WestLangley / http://github.com/WestLangley
+ *
+ * W3C Device Orientation control (http://w3c.github.io/deviceorientation/spec-source-orientation.html)
+ */
+
+/* NOTE that this is a modified version of THREE.DeviceOrientationControls to 
+ * allow exponential smoothing, for use in AR.js.
+ *
+ * Modifications Nick Whitelegg (nickw1 github)
+ */
+
+ArjsDeviceOrientationControls =  function ( object ) {
+
+  var scope = this;
+
+  this.object = object;
+  this.object.rotation.reorder( 'YXZ' );
+
+  this.enabled = true;
+
+  this.deviceOrientation = {};
+  this.screenOrientation = 0;
+
+  this.alphaOffset = 0; // radians
+
+  this.smoothingFactor = 1;
+
+  var onDeviceOrientationChangeEvent = function ( event ) {
+
+    scope.deviceOrientation = event;
+
+  };
+
+  var onScreenOrientationChangeEvent = function () {
+
+    scope.screenOrientation = window.orientation || 0;
+
+  };
+
+  // The angles alpha, beta and gamma form a set of intrinsic Tait-Bryan angles of type Z-X'-Y''
+
+  var setObjectQuaternion = function () {
+
+    var zee = new THREE.Vector3( 0, 0, 1 );
+
+    var euler = new THREE.Euler();
+
+    var q0 = new THREE.Quaternion();
+
+    var q1 = new THREE.Quaternion( - Math.sqrt( 0.5 ), 0, 0, Math.sqrt( 0.5 ) ); // - PI/2 around the x-axis
+
+    return function ( quaternion, alpha, beta, gamma, orient ) {
+
+      euler.set( beta, alpha, - gamma, 'YXZ' ); // 'ZXY' for the device, but 'YXZ' for us
+
+      quaternion.setFromEuler( euler ); // orient the device
+
+      quaternion.multiply( q1 ); // camera looks out the back of the device, not the top
+
+      quaternion.multiply( q0.setFromAxisAngle( zee, - orient ) ); // adjust for screen orientation
+
+    };
+
+  }();
+
+  this.connect = function () {
+ 
+    onScreenOrientationChangeEvent();
+
+    window.addEventListener( 'orientationchange', onScreenOrientationChangeEvent, false );
+    window.addEventListener( 'deviceorientation', onDeviceOrientationChangeEvent, false );
+
+    scope.enabled = true;
+
+  };
+
+  this.disconnect = function () {
+
+    window.removeEventListener( 'orientationchange', onScreenOrientationChangeEvent, false );
+    window.removeEventListener( 'deviceorientation', onDeviceOrientationChangeEvent, false );
+
+    scope.enabled = false;
+
+  };
+
+  this.update = function () {
+
+    if ( scope.enabled === false ) return;
+
+    var device = scope.deviceOrientation;
+
+    if ( device ) {
+
+      var alpha = device.alpha ? THREE.Math.degToRad( device.alpha ) + scope.alphaOffset : 0; // Z
+
+      var beta = device.beta ? THREE.Math.degToRad( device.beta ) : 0; // X'
+
+      var gamma = device.gamma ? THREE.Math.degToRad( device.gamma ) : 0; // Y''
+
+      var orient = scope.screenOrientation ? THREE.Math.degToRad( scope.screenOrientation ) : 0; // O
+      
+      // NW ORIENTATION SMOOTHING 
+
+      if(this.lastOrientation) {
+        alpha = this._getSmoothedAngle(alpha , this.lastOrientation.alpha, this.smoothingFactor);
+        beta = this._getSmoothedAngle(beta + (beta < 0 ? 360 : 0) , this.lastOrientation.beta, this.smoothingFactor);
+        gamma = this._getSmoothedAngle(gamma + (gamma < 0 ? 180 : 0) , this.lastOrientation.gamma, this.smoothingFactor, 180);
+
+        this.lastOrientation = {
+          alpha: alpha,
+          beta: beta,
+          gamma: gamma
+        };
+      } else {
+        this.lastOrientation = {
+          alpha: alpha,
+          beta: beta + (beta < 0 ? 360 : 0),
+          gamma: gamma + (gamma < 0 ? 180 :0)
+        };
+      }
+      // NW END ADDED CODE
+      setObjectQuaternion( scope.object.quaternion, alpha, beta, gamma, orient );
+
+    }
+
+
+  };
+
+  // NW ADDED 
+  // Orders two angles 
+  this._orderAngle = function (a, b, r = 360) {
+    if ((b > a && Math.abs(b - a) < r / 2) || (a > b && Math.abs(b - a) > r / 2)) {
+      return { lesser: a, greater: b };
+    } else { 
+      return { lesser: b, greater: a };
+    }
+  };
+
+  // NW ALSO ADDED THIS METHOD
+  // get a smoothed angle
+  this._getSmoothedAngle = function (a, b, k, r = 360) {
+    var angles = this._orderAngle(a,b,r);
+    var angleshift = angles.lesser;
+    var origGreater = angles.greater;
+    angles.lesser = 0;
+    angles.greater -= angleshift;
+    if(angles.greater < 0) angles.greater += r;
+    var newangle = origGreater == b ? (1 - k) * angles.greater + k * angles.lesser : k * angles.greater + (1 - k) * angles.lesser;
+    newangle += angleshift;
+    if(newangle >= r) newangle -= r;
+    return newangle;
+  };
+
+  this.dispose = function () {
+
+    scope.disconnect();
+
+  };
+
+  this.connect();
+
+};
+// To avoid recalculation at every mouse movement tick
+var PI_2 = Math.PI / 2;
+
+
+/**
+ * look-controls. Update entity pose, factoring mouse, touch, and WebVR API data.
+ */
+
+/* NOTE that this is a modified version of A-Frame's look-controls to 
+ * allow exponential smoothing, for use in AR.js.
+ *
+ * Modifications Nick Whitelegg (nickw1 github)
+ */
+
+AFRAME.registerComponent('arjs-look-controls', {
+  dependencies: ['position', 'rotation'],
+
+  schema: {
+    enabled: {default: true},
+    magicWindowTrackingEnabled: {default: true},
+    pointerLockEnabled: {default: false},
+    reverseMouseDrag: {default: false},
+    reverseTouchDrag: {default: false},
+    touchEnabled: {default: true},
+    smoothingFactor: { type: 'number', default: 1 }
+  },
+
+  init: function () {
+    this.deltaYaw = 0;
+    this.previousHMDPosition = new THREE.Vector3();
+    this.hmdQuaternion = new THREE.Quaternion();
+    this.magicWindowAbsoluteEuler = new THREE.Euler();
+    this.magicWindowDeltaEuler = new THREE.Euler();
+    this.position = new THREE.Vector3();
+    this.magicWindowObject = new THREE.Object3D();
+    this.rotation = {};
+    this.deltaRotation = {};
+    this.savedPose = null;
+    this.pointerLocked = false;
+    this.setupMouseControls();
+    this.bindMethods();
+    this.previousMouseEvent = {};
+
+    this.setupMagicWindowControls();
+
+    // To save / restore camera pose
+    this.savedPose = {
+      position: new THREE.Vector3(),
+      rotation: new THREE.Euler()
+    };
+
+    // Call enter VR handler if the scene has entered VR before the event listeners attached.
+    if (this.el.sceneEl.is('vr-mode')) { this.onEnterVR(); }
+  },
+
+  setupMagicWindowControls: function () {
+    var magicWindowControls;
+    var data = this.data;
+
+    // Only on mobile devices and only enabled if DeviceOrientation permission has been granted.
+    if (AFRAME.utils.device.isMobile()) {
+      magicWindowControls = this.magicWindowControls = new ArjsDeviceOrientationControls(this.magicWindowObject);
+      if (typeof DeviceOrientationEvent !== 'undefined' && DeviceOrientationEvent.requestPermission) {
+        magicWindowControls.enabled = false;
+        if (this.el.sceneEl.components['device-orientation-permission-ui'].permissionGranted) {
+          magicWindowControls.enabled = data.magicWindowTrackingEnabled;
+        } else {
+          this.el.sceneEl.addEventListener('deviceorientationpermissiongranted', function () {
+            magicWindowControls.enabled = data.magicWindowTrackingEnabled;
+          });
+        }
+      }
+    }
+  },
+
+  update: function (oldData) {
+    var data = this.data;
+
+    // Disable grab cursor classes if no longer enabled.
+    if (data.enabled !== oldData.enabled) {
+      this.updateGrabCursor(data.enabled);
+    }
+
+    // Reset magic window eulers if tracking is disabled.
+    if (oldData && !data.magicWindowTrackingEnabled && oldData.magicWindowTrackingEnabled) {
+      this.magicWindowAbsoluteEuler.set(0, 0, 0);
+      this.magicWindowDeltaEuler.set(0, 0, 0);
+    }
+
+    // Pass on magic window tracking setting to magicWindowControls.
+    if (this.magicWindowControls) {
+      this.magicWindowControls.enabled = data.magicWindowTrackingEnabled;
+      this.magicWindowControls.smoothingFactor = data.smoothingFactor;
+    }
+
+    if (oldData && !data.pointerLockEnabled !== oldData.pointerLockEnabled) {
+      this.removeEventListeners();
+      this.addEventListeners();
+      if (this.pointerLocked) { this.exitPointerLock(); }
+    }
+  },
+
+  tick: function (t) {
+    var data = this.data;
+    if (!data.enabled) { return; }
+    this.updateOrientation();
+  },
+
+  play: function () {
+    this.addEventListeners();
+  },
+
+  pause: function () {
+    this.removeEventListeners();
+    if (this.pointerLocked) { this.exitPointerLock(); }
+  },
+
+  remove: function () {
+    this.removeEventListeners();
+    if (this.pointerLocked) { this.exitPointerLock(); }
+  },
+
+  bindMethods: function () {
+    this.onMouseDown = AFRAME.utils.bind(this.onMouseDown, this);
+    this.onMouseMove = AFRAME.utils.bind(this.onMouseMove, this);
+    this.onMouseUp = AFRAME.utils.bind(this.onMouseUp, this);
+    this.onTouchStart = AFRAME.utils.bind(this.onTouchStart, this);
+    this.onTouchMove = AFRAME.utils.bind(this.onTouchMove, this);
+    this.onTouchEnd = AFRAME.utils.bind(this.onTouchEnd, this);
+    this.onEnterVR = AFRAME.utils.bind(this.onEnterVR, this);
+    this.onExitVR = AFRAME.utils.bind(this.onExitVR, this);
+    this.onPointerLockChange = AFRAME.utils.bind(this.onPointerLockChange, this);
+    this.onPointerLockError = AFRAME.utils.bind(this.onPointerLockError, this);
+  },
+
+ /**
+  * Set up states and Object3Ds needed to store rotation data.
+  */
+  setupMouseControls: function () {
+    this.mouseDown = false;
+    this.pitchObject = new THREE.Object3D();
+    this.yawObject = new THREE.Object3D();
+    this.yawObject.position.y = 10;
+    this.yawObject.add(this.pitchObject);
+  },
+
+  /**
+   * Add mouse and touch event listeners to canvas.
+   */
+  addEventListeners: function () {
+    var sceneEl = this.el.sceneEl;
+    var canvasEl = sceneEl.canvas;
+
+    // Wait for canvas to load.
+    if (!canvasEl) {
+      sceneEl.addEventListener('render-target-loaded', AFRAME.utils.bind(this.addEventListeners, this));
+      return;
+    }
+
+    // Mouse events.
+    canvasEl.addEventListener('mousedown', this.onMouseDown, false);
+    window.addEventListener('mousemove', this.onMouseMove, false);
+    window.addEventListener('mouseup', this.onMouseUp, false);
+
+    // Touch events.
+    canvasEl.addEventListener('touchstart', this.onTouchStart);
+    window.addEventListener('touchmove', this.onTouchMove);
+    window.addEventListener('touchend', this.onTouchEnd);
+
+    // sceneEl events.
+    sceneEl.addEventListener('enter-vr', this.onEnterVR);
+    sceneEl.addEventListener('exit-vr', this.onExitVR);
+
+    // Pointer Lock events.
+    if (this.data.pointerLockEnabled) {
+      document.addEventListener('pointerlockchange', this.onPointerLockChange, false);
+      document.addEventListener('mozpointerlockchange', this.onPointerLockChange, false);
+      document.addEventListener('pointerlockerror', this.onPointerLockError, false);
+    }
+  },
+
+  /**
+   * Remove mouse and touch event listeners from canvas.
+   */
+  removeEventListeners: function () {
+    var sceneEl = this.el.sceneEl;
+    var canvasEl = sceneEl && sceneEl.canvas;
+
+    if (!canvasEl) { return; }
+
+    // Mouse events.
+    canvasEl.removeEventListener('mousedown', this.onMouseDown);
+    window.removeEventListener('mousemove', this.onMouseMove);
+    window.removeEventListener('mouseup', this.onMouseUp);
+
+    // Touch events.
+    canvasEl.removeEventListener('touchstart', this.onTouchStart);
+    window.removeEventListener('touchmove', this.onTouchMove);
+    window.removeEventListener('touchend', this.onTouchEnd);
+
+    // sceneEl events.
+    sceneEl.removeEventListener('enter-vr', this.onEnterVR);
+    sceneEl.removeEventListener('exit-vr', this.onExitVR);
+
+    // Pointer Lock events.
+    document.removeEventListener('pointerlockchange', this.onPointerLockChange, false);
+    document.removeEventListener('mozpointerlockchange', this.onPointerLockChange, false);
+    document.removeEventListener('pointerlockerror', this.onPointerLockError, false);
+  },
+
+  /**
+   * Update orientation for mobile, mouse drag, and headset.
+   * Mouse-drag only enabled if HMD is not active.
+   */
+  updateOrientation: (function () {
+    var poseMatrix = new THREE.Matrix4();
+
+    return function () {
+      var object3D = this.el.object3D;
+      var pitchObject = this.pitchObject;
+      var yawObject = this.yawObject;
+      var pose;
+      var sceneEl = this.el.sceneEl;
+
+      // In VR mode, THREE is in charge of updating the camera pose.
+      if (sceneEl.is('vr-mode') && sceneEl.checkHeadsetConnected()) {
+        // With WebXR THREE applies headset pose to the object3D matrixWorld internally.
+        // Reflect values back on position, rotation, scale for getAttribute to return the expected values.
+        if (sceneEl.hasWebXR) {
+          pose = sceneEl.renderer.xr.getCameraPose();
+          if (pose) {
+            poseMatrix.elements = pose.transform.matrix;
+            poseMatrix.decompose(object3D.position, object3D.rotation, object3D.scale);
+          }
+        }
+        return;
+      }
+
+      this.updateMagicWindowOrientation();
+
+      // On mobile, do camera rotation with touch events and sensors.
+      object3D.rotation.x = this.magicWindowDeltaEuler.x + pitchObject.rotation.x;
+      object3D.rotation.y = this.magicWindowDeltaEuler.y + yawObject.rotation.y;
+      object3D.rotation.z = this.magicWindowDeltaEuler.z;
+    };
+  })(),
+
+  updateMagicWindowOrientation: function () {
+    var magicWindowAbsoluteEuler = this.magicWindowAbsoluteEuler;
+    var magicWindowDeltaEuler = this.magicWindowDeltaEuler;
+    // Calculate magic window HMD quaternion.
+    if (this.magicWindowControls && this.magicWindowControls.enabled) {
+      this.magicWindowControls.update();
+      magicWindowAbsoluteEuler.setFromQuaternion(this.magicWindowObject.quaternion, 'YXZ');
+      if (!this.previousMagicWindowYaw && magicWindowAbsoluteEuler.y !== 0) {
+        this.previousMagicWindowYaw = magicWindowAbsoluteEuler.y;
+      }
+      if (this.previousMagicWindowYaw) {
+        magicWindowDeltaEuler.x = magicWindowAbsoluteEuler.x;
+        magicWindowDeltaEuler.y += magicWindowAbsoluteEuler.y - this.previousMagicWindowYaw;
+        magicWindowDeltaEuler.z = magicWindowAbsoluteEuler.z;
+        this.previousMagicWindowYaw = magicWindowAbsoluteEuler.y;
+      }
+    }
+  },
+
+  /**
+   * Translate mouse drag into rotation.
+   *
+   * Dragging up and down rotates the camera around the X-axis (yaw).
+   * Dragging left and right rotates the camera around the Y-axis (pitch).
+   */
+  onMouseMove: function (evt) {
+    var direction;
+    var movementX;
+    var movementY;
+    var pitchObject = this.pitchObject;
+    var previousMouseEvent = this.previousMouseEvent;
+    var yawObject = this.yawObject;
+
+    // Not dragging or not enabled.
+    if (!this.data.enabled || (!this.mouseDown && !this.pointerLocked)) { return; }
+
+    // Calculate delta.
+    if (this.pointerLocked) {
+      movementX = evt.movementX || evt.mozMovementX || 0;
+      movementY = evt.movementY || evt.mozMovementY || 0;
+    } else {
+      movementX = evt.screenX - previousMouseEvent.screenX;
+      movementY = evt.screenY - previousMouseEvent.screenY;
+    }
+    this.previousMouseEvent.screenX = evt.screenX;
+    this.previousMouseEvent.screenY = evt.screenY;
+
+    // Calculate rotation.
+    direction = this.data.reverseMouseDrag ? 1 : -1;
+    yawObject.rotation.y += movementX * 0.002 * direction;
+    pitchObject.rotation.x += movementY * 0.002 * direction;
+    pitchObject.rotation.x = Math.max(-PI_2, Math.min(PI_2, pitchObject.rotation.x));
+  },
+
+  /**
+   * Register mouse down to detect mouse drag.
+   */
+  onMouseDown: function (evt) {
+    var sceneEl = this.el.sceneEl;
+    if (!this.data.enabled || (sceneEl.is('vr-mode') && sceneEl.checkHeadsetConnected())) { return; }
+    // Handle only primary button.
+    if (evt.button !== 0) { return; }
+
+    var canvasEl = sceneEl && sceneEl.canvas;
+
+    this.mouseDown = true;
+    this.previousMouseEvent.screenX = evt.screenX;
+    this.previousMouseEvent.screenY = evt.screenY;
+    this.showGrabbingCursor();
+
+    if (this.data.pointerLockEnabled && !this.pointerLocked) {
+      if (canvasEl.requestPointerLock) {
+        canvasEl.requestPointerLock();
+      } else if (canvasEl.mozRequestPointerLock) {
+        canvasEl.mozRequestPointerLock();
+      }
+    }
+  },
+
+  /**
+   * Shows grabbing cursor on scene
+   */
+  showGrabbingCursor: function () {
+    this.el.sceneEl.canvas.style.cursor = 'grabbing';
+  },
+
+  /**
+   * Hides grabbing cursor on scene
+   */
+  hideGrabbingCursor: function () {
+    this.el.sceneEl.canvas.style.cursor = '';
+  },
+
+  /**
+   * Register mouse up to detect release of mouse drag.
+   */
+  onMouseUp: function () {
+    this.mouseDown = false;
+    this.hideGrabbingCursor();
+  },
+
+  /**
+   * Register touch down to detect touch drag.
+   */
+  onTouchStart: function (evt) {
+    if (evt.touches.length !== 1 ||
+        !this.data.touchEnabled ||
+        this.el.sceneEl.is('vr-mode')) { return; }
+    this.touchStart = {
+      x: evt.touches[0].pageX,
+      y: evt.touches[0].pageY
+    };
+    this.touchStarted = true;
+  },
+
+  /**
+   * Translate touch move to Y-axis rotation.
+   */
+  onTouchMove: function (evt) {
+    var direction;
+    var canvas = this.el.sceneEl.canvas;
+    var deltaY;
+    var yawObject = this.yawObject;
+
+    if (!this.touchStarted || !this.data.touchEnabled) { return; }
+
+    deltaY = 2 * Math.PI * (evt.touches[0].pageX - this.touchStart.x) / canvas.clientWidth;
+
+    direction = this.data.reverseTouchDrag ? 1 : -1;
+    // Limit touch orientaion to to yaw (y axis).
+    yawObject.rotation.y -= deltaY * 0.5 * direction;
+    this.touchStart = {
+      x: evt.touches[0].pageX,
+      y: evt.touches[0].pageY
+    };
+  },
+
+  /**
+   * Register touch end to detect release of touch drag.
+   */
+  onTouchEnd: function () {
+    this.touchStarted = false;
+  },
+
+  /**
+   * Save pose.
+   */
+  onEnterVR: function () {
+    var sceneEl = this.el.sceneEl;
+    if (!sceneEl.checkHeadsetConnected()) { return; }
+    this.saveCameraPose();
+    this.el.object3D.position.set(0, 0, 0);
+    this.el.object3D.rotation.set(0, 0, 0);
+    if (sceneEl.hasWebXR) {
+      this.el.object3D.matrixAutoUpdate = false;
+      this.el.object3D.updateMatrix();
+    }
+  },
+
+  /**
+   * Restore the pose.
+   */
+  onExitVR: function () {
+    if (!this.el.sceneEl.checkHeadsetConnected()) { return; }
+    this.restoreCameraPose();
+    this.previousHMDPosition.set(0, 0, 0);
+    this.el.object3D.matrixAutoUpdate = true;
+  },
+
+  /**
+   * Update Pointer Lock state.
+   */
+  onPointerLockChange: function () {
+    this.pointerLocked = !!(document.pointerLockElement || document.mozPointerLockElement);
+  },
+
+  /**
+   * Recover from Pointer Lock error.
+   */
+  onPointerLockError: function () {
+    this.pointerLocked = false;
+  },
+
+  // Exits pointer-locked mode.
+  exitPointerLock: function () {
+    document.exitPointerLock();
+    this.pointerLocked = false;
+  },
+
+  /**
+   * Toggle the feature of showing/hiding the grab cursor.
+   */
+  updateGrabCursor: function (enabled) {
+    var sceneEl = this.el.sceneEl;
+
+    function enableGrabCursor () { sceneEl.canvas.classList.add('a-grab-cursor'); }
+    function disableGrabCursor () { sceneEl.canvas.classList.remove('a-grab-cursor'); }
+
+    if (!sceneEl.canvas) {
+      if (enabled) {
+        sceneEl.addEventListener('render-target-loaded', enableGrabCursor);
+      } else {
+        sceneEl.addEventListener('render-target-loaded', disableGrabCursor);
+      }
+      return;
+    }
+
+    if (enabled) {
+      enableGrabCursor();
+      return;
+    }
+    disableGrabCursor();
+  },
+
+  /**
+   * Save camera pose before entering VR to restore later if exiting.
+   */
+  saveCameraPose: function () {
+    var el = this.el;
+
+    this.savedPose.position.copy(el.object3D.position);
+    this.savedPose.rotation.copy(el.object3D.rotation);
+    this.hasSavedPose = true;
+  },
+
+  /**
+   * Reset camera pose to before entering VR.
+   */
+  restoreCameraPose: function () {
+    var el = this.el;
+    var savedPose = this.savedPose;
+
+    if (!this.hasSavedPose) { return; }
+
+    // Reset camera orientation.
+    el.object3D.position.copy(savedPose.position);
+    el.object3D.rotation.copy(savedPose.rotation);
+    this.hasSavedPose = false;
+  }
+});
 AFRAME.registerComponent('arjs-webcam-texture', {
 
     init: function() {
@@ -102,7 +753,7 @@ AFRAME.registerComponent('gps-camera', {
         }
     },
     init: function () {
-        if (!this.el.components['look-controls']) {
+        if (!this.el.components['arjs-look-controls']) {
             return;
         }
 
@@ -125,7 +776,7 @@ AFRAME.registerComponent('gps-camera', {
             }
         }.bind(this));
 
-        this.lookControls = this.el.components['look-controls'];
+        this.lookControls = this.el.components['arjs-look-controls'];
 
         // listen to deviceorientation event
         var eventName = this._getDeviceOrientationEventName();
@@ -649,7 +1300,7 @@ AFRAME.registerComponent('gps-projected-camera', {
         }
     },
     init: function() {
-        if (!this.el.components['look-controls']) {
+        if (!this.el.components['arjs-look-controls']) {
             return;
         }
 
@@ -672,7 +1323,7 @@ AFRAME.registerComponent('gps-projected-camera', {
             }
         }.bind(this));
 
-        this.lookControls = this.el.components['look-controls'];
+        this.lookControls = this.el.components['arjs-look-controls'];
 
         // listen to deviceorientation event
         var eventName = this._getDeviceOrientationEventName();

--- a/aframe/build/aframe-ar-nft.js
+++ b/aframe/build/aframe-ar-nft.js
@@ -3962,6 +3962,657 @@ AFRAME.registerComponent('arjs-hit-testing', {
 		hitTesting.update(camera, arAnchor.object3d, arAnchor.parameters.changeMatrixMode)
 	}
 });
+/**
+ * @author richt / http://richt.me
+ * @author WestLangley / http://github.com/WestLangley
+ *
+ * W3C Device Orientation control (http://w3c.github.io/deviceorientation/spec-source-orientation.html)
+ */
+
+/* NOTE that this is a modified version of THREE.DeviceOrientationControls to 
+ * allow exponential smoothing, for use in AR.js.
+ *
+ * Modifications Nick Whitelegg (nickw1 github)
+ */
+
+ArjsDeviceOrientationControls =  function ( object ) {
+
+  var scope = this;
+
+  this.object = object;
+  this.object.rotation.reorder( 'YXZ' );
+
+  this.enabled = true;
+
+  this.deviceOrientation = {};
+  this.screenOrientation = 0;
+
+  this.alphaOffset = 0; // radians
+
+  this.smoothingFactor = 1;
+
+  var onDeviceOrientationChangeEvent = function ( event ) {
+
+    scope.deviceOrientation = event;
+
+  };
+
+  var onScreenOrientationChangeEvent = function () {
+
+    scope.screenOrientation = window.orientation || 0;
+
+  };
+
+  // The angles alpha, beta and gamma form a set of intrinsic Tait-Bryan angles of type Z-X'-Y''
+
+  var setObjectQuaternion = function () {
+
+    var zee = new THREE.Vector3( 0, 0, 1 );
+
+    var euler = new THREE.Euler();
+
+    var q0 = new THREE.Quaternion();
+
+    var q1 = new THREE.Quaternion( - Math.sqrt( 0.5 ), 0, 0, Math.sqrt( 0.5 ) ); // - PI/2 around the x-axis
+
+    return function ( quaternion, alpha, beta, gamma, orient ) {
+
+      euler.set( beta, alpha, - gamma, 'YXZ' ); // 'ZXY' for the device, but 'YXZ' for us
+
+      quaternion.setFromEuler( euler ); // orient the device
+
+      quaternion.multiply( q1 ); // camera looks out the back of the device, not the top
+
+      quaternion.multiply( q0.setFromAxisAngle( zee, - orient ) ); // adjust for screen orientation
+
+    };
+
+  }();
+
+  this.connect = function () {
+ 
+    onScreenOrientationChangeEvent();
+
+    window.addEventListener( 'orientationchange', onScreenOrientationChangeEvent, false );
+    window.addEventListener( 'deviceorientation', onDeviceOrientationChangeEvent, false );
+
+    scope.enabled = true;
+
+  };
+
+  this.disconnect = function () {
+
+    window.removeEventListener( 'orientationchange', onScreenOrientationChangeEvent, false );
+    window.removeEventListener( 'deviceorientation', onDeviceOrientationChangeEvent, false );
+
+    scope.enabled = false;
+
+  };
+
+  this.update = function () {
+
+    if ( scope.enabled === false ) return;
+
+    var device = scope.deviceOrientation;
+
+    if ( device ) {
+
+      var alpha = device.alpha ? THREE.Math.degToRad( device.alpha ) + scope.alphaOffset : 0; // Z
+
+      var beta = device.beta ? THREE.Math.degToRad( device.beta ) : 0; // X'
+
+      var gamma = device.gamma ? THREE.Math.degToRad( device.gamma ) : 0; // Y''
+
+      var orient = scope.screenOrientation ? THREE.Math.degToRad( scope.screenOrientation ) : 0; // O
+      
+      // NW ORIENTATION SMOOTHING 
+
+      if(this.lastOrientation) {
+        alpha = this._getSmoothedAngle(alpha , this.lastOrientation.alpha, this.smoothingFactor);
+        beta = this._getSmoothedAngle(beta + (beta < 0 ? 360 : 0) , this.lastOrientation.beta, this.smoothingFactor);
+        gamma = this._getSmoothedAngle(gamma + (gamma < 0 ? 180 : 0) , this.lastOrientation.gamma, this.smoothingFactor, 180);
+
+        this.lastOrientation = {
+          alpha: alpha,
+          beta: beta,
+          gamma: gamma
+        };
+      } else {
+        this.lastOrientation = {
+          alpha: alpha,
+          beta: beta + (beta < 0 ? 360 : 0),
+          gamma: gamma + (gamma < 0 ? 180 :0)
+        };
+      }
+      // NW END ADDED CODE
+      setObjectQuaternion( scope.object.quaternion, alpha, beta, gamma, orient );
+
+    }
+
+
+  };
+
+  // NW ADDED 
+  // Orders two angles 
+  this._orderAngle = function (a, b, r = 360) {
+    if ((b > a && Math.abs(b - a) < r / 2) || (a > b && Math.abs(b - a) > r / 2)) {
+      return { lesser: a, greater: b };
+    } else { 
+      return { lesser: b, greater: a };
+    }
+  };
+
+  // NW ALSO ADDED THIS METHOD
+  // get a smoothed angle
+  this._getSmoothedAngle = function (a, b, k, r = 360) {
+    var angles = this._orderAngle(a,b,r);
+    var angleshift = angles.lesser;
+    var origGreater = angles.greater;
+    angles.lesser = 0;
+    angles.greater -= angleshift;
+    if(angles.greater < 0) angles.greater += r;
+    var newangle = origGreater == b ? (1 - k) * angles.greater + k * angles.lesser : k * angles.greater + (1 - k) * angles.lesser;
+    newangle += angleshift;
+    if(newangle >= r) newangle -= r;
+    return newangle;
+  };
+
+  this.dispose = function () {
+
+    scope.disconnect();
+
+  };
+
+  this.connect();
+
+};
+// To avoid recalculation at every mouse movement tick
+var PI_2 = Math.PI / 2;
+
+
+/**
+ * look-controls. Update entity pose, factoring mouse, touch, and WebVR API data.
+ */
+
+/* NOTE that this is a modified version of A-Frame's look-controls to 
+ * allow exponential smoothing, for use in AR.js.
+ *
+ * Modifications Nick Whitelegg (nickw1 github)
+ */
+
+AFRAME.registerComponent('arjs-look-controls', {
+  dependencies: ['position', 'rotation'],
+
+  schema: {
+    enabled: {default: true},
+    magicWindowTrackingEnabled: {default: true},
+    pointerLockEnabled: {default: false},
+    reverseMouseDrag: {default: false},
+    reverseTouchDrag: {default: false},
+    touchEnabled: {default: true},
+    smoothingFactor: { type: 'number', default: 1 }
+  },
+
+  init: function () {
+    this.deltaYaw = 0;
+    this.previousHMDPosition = new THREE.Vector3();
+    this.hmdQuaternion = new THREE.Quaternion();
+    this.magicWindowAbsoluteEuler = new THREE.Euler();
+    this.magicWindowDeltaEuler = new THREE.Euler();
+    this.position = new THREE.Vector3();
+    this.magicWindowObject = new THREE.Object3D();
+    this.rotation = {};
+    this.deltaRotation = {};
+    this.savedPose = null;
+    this.pointerLocked = false;
+    this.setupMouseControls();
+    this.bindMethods();
+    this.previousMouseEvent = {};
+
+    this.setupMagicWindowControls();
+
+    // To save / restore camera pose
+    this.savedPose = {
+      position: new THREE.Vector3(),
+      rotation: new THREE.Euler()
+    };
+
+    // Call enter VR handler if the scene has entered VR before the event listeners attached.
+    if (this.el.sceneEl.is('vr-mode')) { this.onEnterVR(); }
+  },
+
+  setupMagicWindowControls: function () {
+    var magicWindowControls;
+    var data = this.data;
+
+    // Only on mobile devices and only enabled if DeviceOrientation permission has been granted.
+    if (AFRAME.utils.device.isMobile()) {
+      magicWindowControls = this.magicWindowControls = new ArjsDeviceOrientationControls(this.magicWindowObject);
+      if (typeof DeviceOrientationEvent !== 'undefined' && DeviceOrientationEvent.requestPermission) {
+        magicWindowControls.enabled = false;
+        if (this.el.sceneEl.components['device-orientation-permission-ui'].permissionGranted) {
+          magicWindowControls.enabled = data.magicWindowTrackingEnabled;
+        } else {
+          this.el.sceneEl.addEventListener('deviceorientationpermissiongranted', function () {
+            magicWindowControls.enabled = data.magicWindowTrackingEnabled;
+          });
+        }
+      }
+    }
+  },
+
+  update: function (oldData) {
+    var data = this.data;
+
+    // Disable grab cursor classes if no longer enabled.
+    if (data.enabled !== oldData.enabled) {
+      this.updateGrabCursor(data.enabled);
+    }
+
+    // Reset magic window eulers if tracking is disabled.
+    if (oldData && !data.magicWindowTrackingEnabled && oldData.magicWindowTrackingEnabled) {
+      this.magicWindowAbsoluteEuler.set(0, 0, 0);
+      this.magicWindowDeltaEuler.set(0, 0, 0);
+    }
+
+    // Pass on magic window tracking setting to magicWindowControls.
+    if (this.magicWindowControls) {
+      this.magicWindowControls.enabled = data.magicWindowTrackingEnabled;
+      this.magicWindowControls.smoothingFactor = data.smoothingFactor;
+    }
+
+    if (oldData && !data.pointerLockEnabled !== oldData.pointerLockEnabled) {
+      this.removeEventListeners();
+      this.addEventListeners();
+      if (this.pointerLocked) { this.exitPointerLock(); }
+    }
+  },
+
+  tick: function (t) {
+    var data = this.data;
+    if (!data.enabled) { return; }
+    this.updateOrientation();
+  },
+
+  play: function () {
+    this.addEventListeners();
+  },
+
+  pause: function () {
+    this.removeEventListeners();
+    if (this.pointerLocked) { this.exitPointerLock(); }
+  },
+
+  remove: function () {
+    this.removeEventListeners();
+    if (this.pointerLocked) { this.exitPointerLock(); }
+  },
+
+  bindMethods: function () {
+    this.onMouseDown = AFRAME.utils.bind(this.onMouseDown, this);
+    this.onMouseMove = AFRAME.utils.bind(this.onMouseMove, this);
+    this.onMouseUp = AFRAME.utils.bind(this.onMouseUp, this);
+    this.onTouchStart = AFRAME.utils.bind(this.onTouchStart, this);
+    this.onTouchMove = AFRAME.utils.bind(this.onTouchMove, this);
+    this.onTouchEnd = AFRAME.utils.bind(this.onTouchEnd, this);
+    this.onEnterVR = AFRAME.utils.bind(this.onEnterVR, this);
+    this.onExitVR = AFRAME.utils.bind(this.onExitVR, this);
+    this.onPointerLockChange = AFRAME.utils.bind(this.onPointerLockChange, this);
+    this.onPointerLockError = AFRAME.utils.bind(this.onPointerLockError, this);
+  },
+
+ /**
+  * Set up states and Object3Ds needed to store rotation data.
+  */
+  setupMouseControls: function () {
+    this.mouseDown = false;
+    this.pitchObject = new THREE.Object3D();
+    this.yawObject = new THREE.Object3D();
+    this.yawObject.position.y = 10;
+    this.yawObject.add(this.pitchObject);
+  },
+
+  /**
+   * Add mouse and touch event listeners to canvas.
+   */
+  addEventListeners: function () {
+    var sceneEl = this.el.sceneEl;
+    var canvasEl = sceneEl.canvas;
+
+    // Wait for canvas to load.
+    if (!canvasEl) {
+      sceneEl.addEventListener('render-target-loaded', AFRAME.utils.bind(this.addEventListeners, this));
+      return;
+    }
+
+    // Mouse events.
+    canvasEl.addEventListener('mousedown', this.onMouseDown, false);
+    window.addEventListener('mousemove', this.onMouseMove, false);
+    window.addEventListener('mouseup', this.onMouseUp, false);
+
+    // Touch events.
+    canvasEl.addEventListener('touchstart', this.onTouchStart);
+    window.addEventListener('touchmove', this.onTouchMove);
+    window.addEventListener('touchend', this.onTouchEnd);
+
+    // sceneEl events.
+    sceneEl.addEventListener('enter-vr', this.onEnterVR);
+    sceneEl.addEventListener('exit-vr', this.onExitVR);
+
+    // Pointer Lock events.
+    if (this.data.pointerLockEnabled) {
+      document.addEventListener('pointerlockchange', this.onPointerLockChange, false);
+      document.addEventListener('mozpointerlockchange', this.onPointerLockChange, false);
+      document.addEventListener('pointerlockerror', this.onPointerLockError, false);
+    }
+  },
+
+  /**
+   * Remove mouse and touch event listeners from canvas.
+   */
+  removeEventListeners: function () {
+    var sceneEl = this.el.sceneEl;
+    var canvasEl = sceneEl && sceneEl.canvas;
+
+    if (!canvasEl) { return; }
+
+    // Mouse events.
+    canvasEl.removeEventListener('mousedown', this.onMouseDown);
+    window.removeEventListener('mousemove', this.onMouseMove);
+    window.removeEventListener('mouseup', this.onMouseUp);
+
+    // Touch events.
+    canvasEl.removeEventListener('touchstart', this.onTouchStart);
+    window.removeEventListener('touchmove', this.onTouchMove);
+    window.removeEventListener('touchend', this.onTouchEnd);
+
+    // sceneEl events.
+    sceneEl.removeEventListener('enter-vr', this.onEnterVR);
+    sceneEl.removeEventListener('exit-vr', this.onExitVR);
+
+    // Pointer Lock events.
+    document.removeEventListener('pointerlockchange', this.onPointerLockChange, false);
+    document.removeEventListener('mozpointerlockchange', this.onPointerLockChange, false);
+    document.removeEventListener('pointerlockerror', this.onPointerLockError, false);
+  },
+
+  /**
+   * Update orientation for mobile, mouse drag, and headset.
+   * Mouse-drag only enabled if HMD is not active.
+   */
+  updateOrientation: (function () {
+    var poseMatrix = new THREE.Matrix4();
+
+    return function () {
+      var object3D = this.el.object3D;
+      var pitchObject = this.pitchObject;
+      var yawObject = this.yawObject;
+      var pose;
+      var sceneEl = this.el.sceneEl;
+
+      // In VR mode, THREE is in charge of updating the camera pose.
+      if (sceneEl.is('vr-mode') && sceneEl.checkHeadsetConnected()) {
+        // With WebXR THREE applies headset pose to the object3D matrixWorld internally.
+        // Reflect values back on position, rotation, scale for getAttribute to return the expected values.
+        if (sceneEl.hasWebXR) {
+          pose = sceneEl.renderer.xr.getCameraPose();
+          if (pose) {
+            poseMatrix.elements = pose.transform.matrix;
+            poseMatrix.decompose(object3D.position, object3D.rotation, object3D.scale);
+          }
+        }
+        return;
+      }
+
+      this.updateMagicWindowOrientation();
+
+      // On mobile, do camera rotation with touch events and sensors.
+      object3D.rotation.x = this.magicWindowDeltaEuler.x + pitchObject.rotation.x;
+      object3D.rotation.y = this.magicWindowDeltaEuler.y + yawObject.rotation.y;
+      object3D.rotation.z = this.magicWindowDeltaEuler.z;
+    };
+  })(),
+
+  updateMagicWindowOrientation: function () {
+    var magicWindowAbsoluteEuler = this.magicWindowAbsoluteEuler;
+    var magicWindowDeltaEuler = this.magicWindowDeltaEuler;
+    // Calculate magic window HMD quaternion.
+    if (this.magicWindowControls && this.magicWindowControls.enabled) {
+      this.magicWindowControls.update();
+      magicWindowAbsoluteEuler.setFromQuaternion(this.magicWindowObject.quaternion, 'YXZ');
+      if (!this.previousMagicWindowYaw && magicWindowAbsoluteEuler.y !== 0) {
+        this.previousMagicWindowYaw = magicWindowAbsoluteEuler.y;
+      }
+      if (this.previousMagicWindowYaw) {
+        magicWindowDeltaEuler.x = magicWindowAbsoluteEuler.x;
+        magicWindowDeltaEuler.y += magicWindowAbsoluteEuler.y - this.previousMagicWindowYaw;
+        magicWindowDeltaEuler.z = magicWindowAbsoluteEuler.z;
+        this.previousMagicWindowYaw = magicWindowAbsoluteEuler.y;
+      }
+    }
+  },
+
+  /**
+   * Translate mouse drag into rotation.
+   *
+   * Dragging up and down rotates the camera around the X-axis (yaw).
+   * Dragging left and right rotates the camera around the Y-axis (pitch).
+   */
+  onMouseMove: function (evt) {
+    var direction;
+    var movementX;
+    var movementY;
+    var pitchObject = this.pitchObject;
+    var previousMouseEvent = this.previousMouseEvent;
+    var yawObject = this.yawObject;
+
+    // Not dragging or not enabled.
+    if (!this.data.enabled || (!this.mouseDown && !this.pointerLocked)) { return; }
+
+    // Calculate delta.
+    if (this.pointerLocked) {
+      movementX = evt.movementX || evt.mozMovementX || 0;
+      movementY = evt.movementY || evt.mozMovementY || 0;
+    } else {
+      movementX = evt.screenX - previousMouseEvent.screenX;
+      movementY = evt.screenY - previousMouseEvent.screenY;
+    }
+    this.previousMouseEvent.screenX = evt.screenX;
+    this.previousMouseEvent.screenY = evt.screenY;
+
+    // Calculate rotation.
+    direction = this.data.reverseMouseDrag ? 1 : -1;
+    yawObject.rotation.y += movementX * 0.002 * direction;
+    pitchObject.rotation.x += movementY * 0.002 * direction;
+    pitchObject.rotation.x = Math.max(-PI_2, Math.min(PI_2, pitchObject.rotation.x));
+  },
+
+  /**
+   * Register mouse down to detect mouse drag.
+   */
+  onMouseDown: function (evt) {
+    var sceneEl = this.el.sceneEl;
+    if (!this.data.enabled || (sceneEl.is('vr-mode') && sceneEl.checkHeadsetConnected())) { return; }
+    // Handle only primary button.
+    if (evt.button !== 0) { return; }
+
+    var canvasEl = sceneEl && sceneEl.canvas;
+
+    this.mouseDown = true;
+    this.previousMouseEvent.screenX = evt.screenX;
+    this.previousMouseEvent.screenY = evt.screenY;
+    this.showGrabbingCursor();
+
+    if (this.data.pointerLockEnabled && !this.pointerLocked) {
+      if (canvasEl.requestPointerLock) {
+        canvasEl.requestPointerLock();
+      } else if (canvasEl.mozRequestPointerLock) {
+        canvasEl.mozRequestPointerLock();
+      }
+    }
+  },
+
+  /**
+   * Shows grabbing cursor on scene
+   */
+  showGrabbingCursor: function () {
+    this.el.sceneEl.canvas.style.cursor = 'grabbing';
+  },
+
+  /**
+   * Hides grabbing cursor on scene
+   */
+  hideGrabbingCursor: function () {
+    this.el.sceneEl.canvas.style.cursor = '';
+  },
+
+  /**
+   * Register mouse up to detect release of mouse drag.
+   */
+  onMouseUp: function () {
+    this.mouseDown = false;
+    this.hideGrabbingCursor();
+  },
+
+  /**
+   * Register touch down to detect touch drag.
+   */
+  onTouchStart: function (evt) {
+    if (evt.touches.length !== 1 ||
+        !this.data.touchEnabled ||
+        this.el.sceneEl.is('vr-mode')) { return; }
+    this.touchStart = {
+      x: evt.touches[0].pageX,
+      y: evt.touches[0].pageY
+    };
+    this.touchStarted = true;
+  },
+
+  /**
+   * Translate touch move to Y-axis rotation.
+   */
+  onTouchMove: function (evt) {
+    var direction;
+    var canvas = this.el.sceneEl.canvas;
+    var deltaY;
+    var yawObject = this.yawObject;
+
+    if (!this.touchStarted || !this.data.touchEnabled) { return; }
+
+    deltaY = 2 * Math.PI * (evt.touches[0].pageX - this.touchStart.x) / canvas.clientWidth;
+
+    direction = this.data.reverseTouchDrag ? 1 : -1;
+    // Limit touch orientaion to to yaw (y axis).
+    yawObject.rotation.y -= deltaY * 0.5 * direction;
+    this.touchStart = {
+      x: evt.touches[0].pageX,
+      y: evt.touches[0].pageY
+    };
+  },
+
+  /**
+   * Register touch end to detect release of touch drag.
+   */
+  onTouchEnd: function () {
+    this.touchStarted = false;
+  },
+
+  /**
+   * Save pose.
+   */
+  onEnterVR: function () {
+    var sceneEl = this.el.sceneEl;
+    if (!sceneEl.checkHeadsetConnected()) { return; }
+    this.saveCameraPose();
+    this.el.object3D.position.set(0, 0, 0);
+    this.el.object3D.rotation.set(0, 0, 0);
+    if (sceneEl.hasWebXR) {
+      this.el.object3D.matrixAutoUpdate = false;
+      this.el.object3D.updateMatrix();
+    }
+  },
+
+  /**
+   * Restore the pose.
+   */
+  onExitVR: function () {
+    if (!this.el.sceneEl.checkHeadsetConnected()) { return; }
+    this.restoreCameraPose();
+    this.previousHMDPosition.set(0, 0, 0);
+    this.el.object3D.matrixAutoUpdate = true;
+  },
+
+  /**
+   * Update Pointer Lock state.
+   */
+  onPointerLockChange: function () {
+    this.pointerLocked = !!(document.pointerLockElement || document.mozPointerLockElement);
+  },
+
+  /**
+   * Recover from Pointer Lock error.
+   */
+  onPointerLockError: function () {
+    this.pointerLocked = false;
+  },
+
+  // Exits pointer-locked mode.
+  exitPointerLock: function () {
+    document.exitPointerLock();
+    this.pointerLocked = false;
+  },
+
+  /**
+   * Toggle the feature of showing/hiding the grab cursor.
+   */
+  updateGrabCursor: function (enabled) {
+    var sceneEl = this.el.sceneEl;
+
+    function enableGrabCursor () { sceneEl.canvas.classList.add('a-grab-cursor'); }
+    function disableGrabCursor () { sceneEl.canvas.classList.remove('a-grab-cursor'); }
+
+    if (!sceneEl.canvas) {
+      if (enabled) {
+        sceneEl.addEventListener('render-target-loaded', enableGrabCursor);
+      } else {
+        sceneEl.addEventListener('render-target-loaded', disableGrabCursor);
+      }
+      return;
+    }
+
+    if (enabled) {
+      enableGrabCursor();
+      return;
+    }
+    disableGrabCursor();
+  },
+
+  /**
+   * Save camera pose before entering VR to restore later if exiting.
+   */
+  saveCameraPose: function () {
+    var el = this.el;
+
+    this.savedPose.position.copy(el.object3D.position);
+    this.savedPose.rotation.copy(el.object3D.rotation);
+    this.hasSavedPose = true;
+  },
+
+  /**
+   * Reset camera pose to before entering VR.
+   */
+  restoreCameraPose: function () {
+    var el = this.el;
+    var savedPose = this.savedPose;
+
+    if (!this.hasSavedPose) { return; }
+
+    // Reset camera orientation.
+    el.object3D.position.copy(savedPose.position);
+    el.object3D.rotation.copy(savedPose.rotation);
+    this.hasSavedPose = false;
+  }
+});
 AFRAME.registerComponent('arjs-webcam-texture', {
 
     init: function() {
@@ -4066,7 +4717,7 @@ AFRAME.registerComponent('gps-camera', {
         }
     },
     init: function () {
-        if (!this.el.components['look-controls']) {
+        if (!this.el.components['arjs-look-controls']) {
             return;
         }
 
@@ -4089,7 +4740,7 @@ AFRAME.registerComponent('gps-camera', {
             }
         }.bind(this));
 
-        this.lookControls = this.el.components['look-controls'];
+        this.lookControls = this.el.components['arjs-look-controls'];
 
         // listen to deviceorientation event
         var eventName = this._getDeviceOrientationEventName();
@@ -4613,7 +5264,7 @@ AFRAME.registerComponent('gps-projected-camera', {
         }
     },
     init: function() {
-        if (!this.el.components['look-controls']) {
+        if (!this.el.components['arjs-look-controls']) {
             return;
         }
 
@@ -4636,7 +5287,7 @@ AFRAME.registerComponent('gps-projected-camera', {
             }
         }.bind(this));
 
-        this.lookControls = this.el.components['look-controls'];
+        this.lookControls = this.el.components['arjs-look-controls'];
 
         // listen to deviceorientation event
         var eventName = this._getDeviceOrientationEventName();

--- a/aframe/build/aframe-ar-nft.js
+++ b/aframe/build/aframe-ar-nft.js
@@ -4717,7 +4717,7 @@ AFRAME.registerComponent('gps-camera', {
         }
     },
     init: function () {
-        if (!this.el.components['arjs-look-controls']) {
+        if (!this.el.components['arjs-look-controls'] && !this.el.components['look-controls']) {
             return;
         }
 
@@ -4740,7 +4740,7 @@ AFRAME.registerComponent('gps-camera', {
             }
         }.bind(this));
 
-        this.lookControls = this.el.components['arjs-look-controls'];
+        this.lookControls = this.el.components['arjs-look-controls'] || this.el.components['look-controls'];
 
         // listen to deviceorientation event
         var eventName = this._getDeviceOrientationEventName();
@@ -5264,7 +5264,7 @@ AFRAME.registerComponent('gps-projected-camera', {
         }
     },
     init: function() {
-        if (!this.el.components['arjs-look-controls']) {
+        if (!this.el.components['arjs-look-controls'] && !this.el.components['look-controls']) {
             return;
         }
 
@@ -5287,7 +5287,7 @@ AFRAME.registerComponent('gps-projected-camera', {
             }
         }.bind(this));
 
-        this.lookControls = this.el.components['arjs-look-controls'];
+        this.lookControls = this.el.components['arjs-look-controls'] || this.el.components['look-controls'];
 
         // listen to deviceorientation event
         var eventName = this._getDeviceOrientationEventName();

--- a/aframe/build/aframe-ar.js
+++ b/aframe/build/aframe-ar.js
@@ -5312,6 +5312,657 @@ AFRAME.registerComponent('arjs-hit-testing', {
 		hitTesting.update(camera, arAnchor.object3d, arAnchor.parameters.changeMatrixMode)
 	}
 });
+/**
+ * @author richt / http://richt.me
+ * @author WestLangley / http://github.com/WestLangley
+ *
+ * W3C Device Orientation control (http://w3c.github.io/deviceorientation/spec-source-orientation.html)
+ */
+
+/* NOTE that this is a modified version of THREE.DeviceOrientationControls to 
+ * allow exponential smoothing, for use in AR.js.
+ *
+ * Modifications Nick Whitelegg (nickw1 github)
+ */
+
+ArjsDeviceOrientationControls =  function ( object ) {
+
+  var scope = this;
+
+  this.object = object;
+  this.object.rotation.reorder( 'YXZ' );
+
+  this.enabled = true;
+
+  this.deviceOrientation = {};
+  this.screenOrientation = 0;
+
+  this.alphaOffset = 0; // radians
+
+  this.smoothingFactor = 1;
+
+  var onDeviceOrientationChangeEvent = function ( event ) {
+
+    scope.deviceOrientation = event;
+
+  };
+
+  var onScreenOrientationChangeEvent = function () {
+
+    scope.screenOrientation = window.orientation || 0;
+
+  };
+
+  // The angles alpha, beta and gamma form a set of intrinsic Tait-Bryan angles of type Z-X'-Y''
+
+  var setObjectQuaternion = function () {
+
+    var zee = new THREE.Vector3( 0, 0, 1 );
+
+    var euler = new THREE.Euler();
+
+    var q0 = new THREE.Quaternion();
+
+    var q1 = new THREE.Quaternion( - Math.sqrt( 0.5 ), 0, 0, Math.sqrt( 0.5 ) ); // - PI/2 around the x-axis
+
+    return function ( quaternion, alpha, beta, gamma, orient ) {
+
+      euler.set( beta, alpha, - gamma, 'YXZ' ); // 'ZXY' for the device, but 'YXZ' for us
+
+      quaternion.setFromEuler( euler ); // orient the device
+
+      quaternion.multiply( q1 ); // camera looks out the back of the device, not the top
+
+      quaternion.multiply( q0.setFromAxisAngle( zee, - orient ) ); // adjust for screen orientation
+
+    };
+
+  }();
+
+  this.connect = function () {
+ 
+    onScreenOrientationChangeEvent();
+
+    window.addEventListener( 'orientationchange', onScreenOrientationChangeEvent, false );
+    window.addEventListener( 'deviceorientation', onDeviceOrientationChangeEvent, false );
+
+    scope.enabled = true;
+
+  };
+
+  this.disconnect = function () {
+
+    window.removeEventListener( 'orientationchange', onScreenOrientationChangeEvent, false );
+    window.removeEventListener( 'deviceorientation', onDeviceOrientationChangeEvent, false );
+
+    scope.enabled = false;
+
+  };
+
+  this.update = function () {
+
+    if ( scope.enabled === false ) return;
+
+    var device = scope.deviceOrientation;
+
+    if ( device ) {
+
+      var alpha = device.alpha ? THREE.Math.degToRad( device.alpha ) + scope.alphaOffset : 0; // Z
+
+      var beta = device.beta ? THREE.Math.degToRad( device.beta ) : 0; // X'
+
+      var gamma = device.gamma ? THREE.Math.degToRad( device.gamma ) : 0; // Y''
+
+      var orient = scope.screenOrientation ? THREE.Math.degToRad( scope.screenOrientation ) : 0; // O
+      
+      // NW ORIENTATION SMOOTHING 
+
+      if(this.lastOrientation) {
+        alpha = this._getSmoothedAngle(alpha , this.lastOrientation.alpha, this.smoothingFactor);
+        beta = this._getSmoothedAngle(beta + (beta < 0 ? 360 : 0) , this.lastOrientation.beta, this.smoothingFactor);
+        gamma = this._getSmoothedAngle(gamma + (gamma < 0 ? 180 : 0) , this.lastOrientation.gamma, this.smoothingFactor, 180);
+
+        this.lastOrientation = {
+          alpha: alpha,
+          beta: beta,
+          gamma: gamma
+        };
+      } else {
+        this.lastOrientation = {
+          alpha: alpha,
+          beta: beta + (beta < 0 ? 360 : 0),
+          gamma: gamma + (gamma < 0 ? 180 :0)
+        };
+      }
+      // NW END ADDED CODE
+      setObjectQuaternion( scope.object.quaternion, alpha, beta, gamma, orient );
+
+    }
+
+
+  };
+
+  // NW ADDED 
+  // Orders two angles 
+  this._orderAngle = function (a, b, r = 360) {
+    if ((b > a && Math.abs(b - a) < r / 2) || (a > b && Math.abs(b - a) > r / 2)) {
+      return { lesser: a, greater: b };
+    } else { 
+      return { lesser: b, greater: a };
+    }
+  };
+
+  // NW ALSO ADDED THIS METHOD
+  // get a smoothed angle
+  this._getSmoothedAngle = function (a, b, k, r = 360) {
+    var angles = this._orderAngle(a,b,r);
+    var angleshift = angles.lesser;
+    var origGreater = angles.greater;
+    angles.lesser = 0;
+    angles.greater -= angleshift;
+    if(angles.greater < 0) angles.greater += r;
+    var newangle = origGreater == b ? (1 - k) * angles.greater + k * angles.lesser : k * angles.greater + (1 - k) * angles.lesser;
+    newangle += angleshift;
+    if(newangle >= r) newangle -= r;
+    return newangle;
+  };
+
+  this.dispose = function () {
+
+    scope.disconnect();
+
+  };
+
+  this.connect();
+
+};
+// To avoid recalculation at every mouse movement tick
+var PI_2 = Math.PI / 2;
+
+
+/**
+ * look-controls. Update entity pose, factoring mouse, touch, and WebVR API data.
+ */
+
+/* NOTE that this is a modified version of A-Frame's look-controls to 
+ * allow exponential smoothing, for use in AR.js.
+ *
+ * Modifications Nick Whitelegg (nickw1 github)
+ */
+
+AFRAME.registerComponent('arjs-look-controls', {
+  dependencies: ['position', 'rotation'],
+
+  schema: {
+    enabled: {default: true},
+    magicWindowTrackingEnabled: {default: true},
+    pointerLockEnabled: {default: false},
+    reverseMouseDrag: {default: false},
+    reverseTouchDrag: {default: false},
+    touchEnabled: {default: true},
+    smoothingFactor: { type: 'number', default: 1 }
+  },
+
+  init: function () {
+    this.deltaYaw = 0;
+    this.previousHMDPosition = new THREE.Vector3();
+    this.hmdQuaternion = new THREE.Quaternion();
+    this.magicWindowAbsoluteEuler = new THREE.Euler();
+    this.magicWindowDeltaEuler = new THREE.Euler();
+    this.position = new THREE.Vector3();
+    this.magicWindowObject = new THREE.Object3D();
+    this.rotation = {};
+    this.deltaRotation = {};
+    this.savedPose = null;
+    this.pointerLocked = false;
+    this.setupMouseControls();
+    this.bindMethods();
+    this.previousMouseEvent = {};
+
+    this.setupMagicWindowControls();
+
+    // To save / restore camera pose
+    this.savedPose = {
+      position: new THREE.Vector3(),
+      rotation: new THREE.Euler()
+    };
+
+    // Call enter VR handler if the scene has entered VR before the event listeners attached.
+    if (this.el.sceneEl.is('vr-mode')) { this.onEnterVR(); }
+  },
+
+  setupMagicWindowControls: function () {
+    var magicWindowControls;
+    var data = this.data;
+
+    // Only on mobile devices and only enabled if DeviceOrientation permission has been granted.
+    if (AFRAME.utils.device.isMobile()) {
+      magicWindowControls = this.magicWindowControls = new ArjsDeviceOrientationControls(this.magicWindowObject);
+      if (typeof DeviceOrientationEvent !== 'undefined' && DeviceOrientationEvent.requestPermission) {
+        magicWindowControls.enabled = false;
+        if (this.el.sceneEl.components['device-orientation-permission-ui'].permissionGranted) {
+          magicWindowControls.enabled = data.magicWindowTrackingEnabled;
+        } else {
+          this.el.sceneEl.addEventListener('deviceorientationpermissiongranted', function () {
+            magicWindowControls.enabled = data.magicWindowTrackingEnabled;
+          });
+        }
+      }
+    }
+  },
+
+  update: function (oldData) {
+    var data = this.data;
+
+    // Disable grab cursor classes if no longer enabled.
+    if (data.enabled !== oldData.enabled) {
+      this.updateGrabCursor(data.enabled);
+    }
+
+    // Reset magic window eulers if tracking is disabled.
+    if (oldData && !data.magicWindowTrackingEnabled && oldData.magicWindowTrackingEnabled) {
+      this.magicWindowAbsoluteEuler.set(0, 0, 0);
+      this.magicWindowDeltaEuler.set(0, 0, 0);
+    }
+
+    // Pass on magic window tracking setting to magicWindowControls.
+    if (this.magicWindowControls) {
+      this.magicWindowControls.enabled = data.magicWindowTrackingEnabled;
+      this.magicWindowControls.smoothingFactor = data.smoothingFactor;
+    }
+
+    if (oldData && !data.pointerLockEnabled !== oldData.pointerLockEnabled) {
+      this.removeEventListeners();
+      this.addEventListeners();
+      if (this.pointerLocked) { this.exitPointerLock(); }
+    }
+  },
+
+  tick: function (t) {
+    var data = this.data;
+    if (!data.enabled) { return; }
+    this.updateOrientation();
+  },
+
+  play: function () {
+    this.addEventListeners();
+  },
+
+  pause: function () {
+    this.removeEventListeners();
+    if (this.pointerLocked) { this.exitPointerLock(); }
+  },
+
+  remove: function () {
+    this.removeEventListeners();
+    if (this.pointerLocked) { this.exitPointerLock(); }
+  },
+
+  bindMethods: function () {
+    this.onMouseDown = AFRAME.utils.bind(this.onMouseDown, this);
+    this.onMouseMove = AFRAME.utils.bind(this.onMouseMove, this);
+    this.onMouseUp = AFRAME.utils.bind(this.onMouseUp, this);
+    this.onTouchStart = AFRAME.utils.bind(this.onTouchStart, this);
+    this.onTouchMove = AFRAME.utils.bind(this.onTouchMove, this);
+    this.onTouchEnd = AFRAME.utils.bind(this.onTouchEnd, this);
+    this.onEnterVR = AFRAME.utils.bind(this.onEnterVR, this);
+    this.onExitVR = AFRAME.utils.bind(this.onExitVR, this);
+    this.onPointerLockChange = AFRAME.utils.bind(this.onPointerLockChange, this);
+    this.onPointerLockError = AFRAME.utils.bind(this.onPointerLockError, this);
+  },
+
+ /**
+  * Set up states and Object3Ds needed to store rotation data.
+  */
+  setupMouseControls: function () {
+    this.mouseDown = false;
+    this.pitchObject = new THREE.Object3D();
+    this.yawObject = new THREE.Object3D();
+    this.yawObject.position.y = 10;
+    this.yawObject.add(this.pitchObject);
+  },
+
+  /**
+   * Add mouse and touch event listeners to canvas.
+   */
+  addEventListeners: function () {
+    var sceneEl = this.el.sceneEl;
+    var canvasEl = sceneEl.canvas;
+
+    // Wait for canvas to load.
+    if (!canvasEl) {
+      sceneEl.addEventListener('render-target-loaded', AFRAME.utils.bind(this.addEventListeners, this));
+      return;
+    }
+
+    // Mouse events.
+    canvasEl.addEventListener('mousedown', this.onMouseDown, false);
+    window.addEventListener('mousemove', this.onMouseMove, false);
+    window.addEventListener('mouseup', this.onMouseUp, false);
+
+    // Touch events.
+    canvasEl.addEventListener('touchstart', this.onTouchStart);
+    window.addEventListener('touchmove', this.onTouchMove);
+    window.addEventListener('touchend', this.onTouchEnd);
+
+    // sceneEl events.
+    sceneEl.addEventListener('enter-vr', this.onEnterVR);
+    sceneEl.addEventListener('exit-vr', this.onExitVR);
+
+    // Pointer Lock events.
+    if (this.data.pointerLockEnabled) {
+      document.addEventListener('pointerlockchange', this.onPointerLockChange, false);
+      document.addEventListener('mozpointerlockchange', this.onPointerLockChange, false);
+      document.addEventListener('pointerlockerror', this.onPointerLockError, false);
+    }
+  },
+
+  /**
+   * Remove mouse and touch event listeners from canvas.
+   */
+  removeEventListeners: function () {
+    var sceneEl = this.el.sceneEl;
+    var canvasEl = sceneEl && sceneEl.canvas;
+
+    if (!canvasEl) { return; }
+
+    // Mouse events.
+    canvasEl.removeEventListener('mousedown', this.onMouseDown);
+    window.removeEventListener('mousemove', this.onMouseMove);
+    window.removeEventListener('mouseup', this.onMouseUp);
+
+    // Touch events.
+    canvasEl.removeEventListener('touchstart', this.onTouchStart);
+    window.removeEventListener('touchmove', this.onTouchMove);
+    window.removeEventListener('touchend', this.onTouchEnd);
+
+    // sceneEl events.
+    sceneEl.removeEventListener('enter-vr', this.onEnterVR);
+    sceneEl.removeEventListener('exit-vr', this.onExitVR);
+
+    // Pointer Lock events.
+    document.removeEventListener('pointerlockchange', this.onPointerLockChange, false);
+    document.removeEventListener('mozpointerlockchange', this.onPointerLockChange, false);
+    document.removeEventListener('pointerlockerror', this.onPointerLockError, false);
+  },
+
+  /**
+   * Update orientation for mobile, mouse drag, and headset.
+   * Mouse-drag only enabled if HMD is not active.
+   */
+  updateOrientation: (function () {
+    var poseMatrix = new THREE.Matrix4();
+
+    return function () {
+      var object3D = this.el.object3D;
+      var pitchObject = this.pitchObject;
+      var yawObject = this.yawObject;
+      var pose;
+      var sceneEl = this.el.sceneEl;
+
+      // In VR mode, THREE is in charge of updating the camera pose.
+      if (sceneEl.is('vr-mode') && sceneEl.checkHeadsetConnected()) {
+        // With WebXR THREE applies headset pose to the object3D matrixWorld internally.
+        // Reflect values back on position, rotation, scale for getAttribute to return the expected values.
+        if (sceneEl.hasWebXR) {
+          pose = sceneEl.renderer.xr.getCameraPose();
+          if (pose) {
+            poseMatrix.elements = pose.transform.matrix;
+            poseMatrix.decompose(object3D.position, object3D.rotation, object3D.scale);
+          }
+        }
+        return;
+      }
+
+      this.updateMagicWindowOrientation();
+
+      // On mobile, do camera rotation with touch events and sensors.
+      object3D.rotation.x = this.magicWindowDeltaEuler.x + pitchObject.rotation.x;
+      object3D.rotation.y = this.magicWindowDeltaEuler.y + yawObject.rotation.y;
+      object3D.rotation.z = this.magicWindowDeltaEuler.z;
+    };
+  })(),
+
+  updateMagicWindowOrientation: function () {
+    var magicWindowAbsoluteEuler = this.magicWindowAbsoluteEuler;
+    var magicWindowDeltaEuler = this.magicWindowDeltaEuler;
+    // Calculate magic window HMD quaternion.
+    if (this.magicWindowControls && this.magicWindowControls.enabled) {
+      this.magicWindowControls.update();
+      magicWindowAbsoluteEuler.setFromQuaternion(this.magicWindowObject.quaternion, 'YXZ');
+      if (!this.previousMagicWindowYaw && magicWindowAbsoluteEuler.y !== 0) {
+        this.previousMagicWindowYaw = magicWindowAbsoluteEuler.y;
+      }
+      if (this.previousMagicWindowYaw) {
+        magicWindowDeltaEuler.x = magicWindowAbsoluteEuler.x;
+        magicWindowDeltaEuler.y += magicWindowAbsoluteEuler.y - this.previousMagicWindowYaw;
+        magicWindowDeltaEuler.z = magicWindowAbsoluteEuler.z;
+        this.previousMagicWindowYaw = magicWindowAbsoluteEuler.y;
+      }
+    }
+  },
+
+  /**
+   * Translate mouse drag into rotation.
+   *
+   * Dragging up and down rotates the camera around the X-axis (yaw).
+   * Dragging left and right rotates the camera around the Y-axis (pitch).
+   */
+  onMouseMove: function (evt) {
+    var direction;
+    var movementX;
+    var movementY;
+    var pitchObject = this.pitchObject;
+    var previousMouseEvent = this.previousMouseEvent;
+    var yawObject = this.yawObject;
+
+    // Not dragging or not enabled.
+    if (!this.data.enabled || (!this.mouseDown && !this.pointerLocked)) { return; }
+
+    // Calculate delta.
+    if (this.pointerLocked) {
+      movementX = evt.movementX || evt.mozMovementX || 0;
+      movementY = evt.movementY || evt.mozMovementY || 0;
+    } else {
+      movementX = evt.screenX - previousMouseEvent.screenX;
+      movementY = evt.screenY - previousMouseEvent.screenY;
+    }
+    this.previousMouseEvent.screenX = evt.screenX;
+    this.previousMouseEvent.screenY = evt.screenY;
+
+    // Calculate rotation.
+    direction = this.data.reverseMouseDrag ? 1 : -1;
+    yawObject.rotation.y += movementX * 0.002 * direction;
+    pitchObject.rotation.x += movementY * 0.002 * direction;
+    pitchObject.rotation.x = Math.max(-PI_2, Math.min(PI_2, pitchObject.rotation.x));
+  },
+
+  /**
+   * Register mouse down to detect mouse drag.
+   */
+  onMouseDown: function (evt) {
+    var sceneEl = this.el.sceneEl;
+    if (!this.data.enabled || (sceneEl.is('vr-mode') && sceneEl.checkHeadsetConnected())) { return; }
+    // Handle only primary button.
+    if (evt.button !== 0) { return; }
+
+    var canvasEl = sceneEl && sceneEl.canvas;
+
+    this.mouseDown = true;
+    this.previousMouseEvent.screenX = evt.screenX;
+    this.previousMouseEvent.screenY = evt.screenY;
+    this.showGrabbingCursor();
+
+    if (this.data.pointerLockEnabled && !this.pointerLocked) {
+      if (canvasEl.requestPointerLock) {
+        canvasEl.requestPointerLock();
+      } else if (canvasEl.mozRequestPointerLock) {
+        canvasEl.mozRequestPointerLock();
+      }
+    }
+  },
+
+  /**
+   * Shows grabbing cursor on scene
+   */
+  showGrabbingCursor: function () {
+    this.el.sceneEl.canvas.style.cursor = 'grabbing';
+  },
+
+  /**
+   * Hides grabbing cursor on scene
+   */
+  hideGrabbingCursor: function () {
+    this.el.sceneEl.canvas.style.cursor = '';
+  },
+
+  /**
+   * Register mouse up to detect release of mouse drag.
+   */
+  onMouseUp: function () {
+    this.mouseDown = false;
+    this.hideGrabbingCursor();
+  },
+
+  /**
+   * Register touch down to detect touch drag.
+   */
+  onTouchStart: function (evt) {
+    if (evt.touches.length !== 1 ||
+        !this.data.touchEnabled ||
+        this.el.sceneEl.is('vr-mode')) { return; }
+    this.touchStart = {
+      x: evt.touches[0].pageX,
+      y: evt.touches[0].pageY
+    };
+    this.touchStarted = true;
+  },
+
+  /**
+   * Translate touch move to Y-axis rotation.
+   */
+  onTouchMove: function (evt) {
+    var direction;
+    var canvas = this.el.sceneEl.canvas;
+    var deltaY;
+    var yawObject = this.yawObject;
+
+    if (!this.touchStarted || !this.data.touchEnabled) { return; }
+
+    deltaY = 2 * Math.PI * (evt.touches[0].pageX - this.touchStart.x) / canvas.clientWidth;
+
+    direction = this.data.reverseTouchDrag ? 1 : -1;
+    // Limit touch orientaion to to yaw (y axis).
+    yawObject.rotation.y -= deltaY * 0.5 * direction;
+    this.touchStart = {
+      x: evt.touches[0].pageX,
+      y: evt.touches[0].pageY
+    };
+  },
+
+  /**
+   * Register touch end to detect release of touch drag.
+   */
+  onTouchEnd: function () {
+    this.touchStarted = false;
+  },
+
+  /**
+   * Save pose.
+   */
+  onEnterVR: function () {
+    var sceneEl = this.el.sceneEl;
+    if (!sceneEl.checkHeadsetConnected()) { return; }
+    this.saveCameraPose();
+    this.el.object3D.position.set(0, 0, 0);
+    this.el.object3D.rotation.set(0, 0, 0);
+    if (sceneEl.hasWebXR) {
+      this.el.object3D.matrixAutoUpdate = false;
+      this.el.object3D.updateMatrix();
+    }
+  },
+
+  /**
+   * Restore the pose.
+   */
+  onExitVR: function () {
+    if (!this.el.sceneEl.checkHeadsetConnected()) { return; }
+    this.restoreCameraPose();
+    this.previousHMDPosition.set(0, 0, 0);
+    this.el.object3D.matrixAutoUpdate = true;
+  },
+
+  /**
+   * Update Pointer Lock state.
+   */
+  onPointerLockChange: function () {
+    this.pointerLocked = !!(document.pointerLockElement || document.mozPointerLockElement);
+  },
+
+  /**
+   * Recover from Pointer Lock error.
+   */
+  onPointerLockError: function () {
+    this.pointerLocked = false;
+  },
+
+  // Exits pointer-locked mode.
+  exitPointerLock: function () {
+    document.exitPointerLock();
+    this.pointerLocked = false;
+  },
+
+  /**
+   * Toggle the feature of showing/hiding the grab cursor.
+   */
+  updateGrabCursor: function (enabled) {
+    var sceneEl = this.el.sceneEl;
+
+    function enableGrabCursor () { sceneEl.canvas.classList.add('a-grab-cursor'); }
+    function disableGrabCursor () { sceneEl.canvas.classList.remove('a-grab-cursor'); }
+
+    if (!sceneEl.canvas) {
+      if (enabled) {
+        sceneEl.addEventListener('render-target-loaded', enableGrabCursor);
+      } else {
+        sceneEl.addEventListener('render-target-loaded', disableGrabCursor);
+      }
+      return;
+    }
+
+    if (enabled) {
+      enableGrabCursor();
+      return;
+    }
+    disableGrabCursor();
+  },
+
+  /**
+   * Save camera pose before entering VR to restore later if exiting.
+   */
+  saveCameraPose: function () {
+    var el = this.el;
+
+    this.savedPose.position.copy(el.object3D.position);
+    this.savedPose.rotation.copy(el.object3D.rotation);
+    this.hasSavedPose = true;
+  },
+
+  /**
+   * Reset camera pose to before entering VR.
+   */
+  restoreCameraPose: function () {
+    var el = this.el;
+    var savedPose = this.savedPose;
+
+    if (!this.hasSavedPose) { return; }
+
+    // Reset camera orientation.
+    el.object3D.position.copy(savedPose.position);
+    el.object3D.rotation.copy(savedPose.rotation);
+    this.hasSavedPose = false;
+  }
+});
 AFRAME.registerComponent('arjs-webcam-texture', {
 
     init: function() {
@@ -5416,7 +6067,7 @@ AFRAME.registerComponent('gps-camera', {
         }
     },
     init: function () {
-        if (!this.el.components['look-controls']) {
+        if (!this.el.components['arjs-look-controls']) {
             return;
         }
 
@@ -5439,7 +6090,7 @@ AFRAME.registerComponent('gps-camera', {
             }
         }.bind(this));
 
-        this.lookControls = this.el.components['look-controls'];
+        this.lookControls = this.el.components['arjs-look-controls'];
 
         // listen to deviceorientation event
         var eventName = this._getDeviceOrientationEventName();
@@ -5963,7 +6614,7 @@ AFRAME.registerComponent('gps-projected-camera', {
         }
     },
     init: function() {
-        if (!this.el.components['look-controls']) {
+        if (!this.el.components['arjs-look-controls']) {
             return;
         }
 
@@ -5986,7 +6637,7 @@ AFRAME.registerComponent('gps-projected-camera', {
             }
         }.bind(this));
 
-        this.lookControls = this.el.components['look-controls'];
+        this.lookControls = this.el.components['arjs-look-controls'];
 
         // listen to deviceorientation event
         var eventName = this._getDeviceOrientationEventName();

--- a/aframe/build/aframe-ar.js
+++ b/aframe/build/aframe-ar.js
@@ -6067,7 +6067,7 @@ AFRAME.registerComponent('gps-camera', {
         }
     },
     init: function () {
-        if (!this.el.components['arjs-look-controls']) {
+        if (!this.el.components['arjs-look-controls'] && !this.el.components['look-controls']) {
             return;
         }
 
@@ -6090,7 +6090,7 @@ AFRAME.registerComponent('gps-camera', {
             }
         }.bind(this));
 
-        this.lookControls = this.el.components['arjs-look-controls'];
+        this.lookControls = this.el.components['arjs-look-controls'] || this.el.components['look-controls'];
 
         // listen to deviceorientation event
         var eventName = this._getDeviceOrientationEventName();
@@ -6614,7 +6614,7 @@ AFRAME.registerComponent('gps-projected-camera', {
         }
     },
     init: function() {
-        if (!this.el.components['arjs-look-controls']) {
+        if (!this.el.components['arjs-look-controls'] && !this.el.components['look-controls']) {
             return;
         }
 
@@ -6637,7 +6637,7 @@ AFRAME.registerComponent('gps-projected-camera', {
             }
         }.bind(this));
 
-        this.lookControls = this.el.components['arjs-look-controls'];
+        this.lookControls = this.el.components['arjs-look-controls'] || this.el.components['look-controls'];
 
         // listen to deviceorientation event
         var eventName = this._getDeviceOrientationEventName();

--- a/aframe/src/location-based/ArjsDeviceOrientationControls.js
+++ b/aframe/src/location-based/ArjsDeviceOrientationControls.js
@@ -1,0 +1,164 @@
+/**
+ * @author richt / http://richt.me
+ * @author WestLangley / http://github.com/WestLangley
+ *
+ * W3C Device Orientation control (http://w3c.github.io/deviceorientation/spec-source-orientation.html)
+ */
+
+/* NOTE that this is a modified version of THREE.DeviceOrientationControls to 
+ * allow exponential smoothing, for use in AR.js.
+ *
+ * Modifications Nick Whitelegg (nickw1 github)
+ */
+
+ArjsDeviceOrientationControls =  function ( object ) {
+
+  var scope = this;
+
+  this.object = object;
+  this.object.rotation.reorder( 'YXZ' );
+
+  this.enabled = true;
+
+  this.deviceOrientation = {};
+  this.screenOrientation = 0;
+
+  this.alphaOffset = 0; // radians
+
+  this.smoothingFactor = 1;
+
+  var onDeviceOrientationChangeEvent = function ( event ) {
+
+    scope.deviceOrientation = event;
+
+  };
+
+  var onScreenOrientationChangeEvent = function () {
+
+    scope.screenOrientation = window.orientation || 0;
+
+  };
+
+  // The angles alpha, beta and gamma form a set of intrinsic Tait-Bryan angles of type Z-X'-Y''
+
+  var setObjectQuaternion = function () {
+
+    var zee = new THREE.Vector3( 0, 0, 1 );
+
+    var euler = new THREE.Euler();
+
+    var q0 = new THREE.Quaternion();
+
+    var q1 = new THREE.Quaternion( - Math.sqrt( 0.5 ), 0, 0, Math.sqrt( 0.5 ) ); // - PI/2 around the x-axis
+
+    return function ( quaternion, alpha, beta, gamma, orient ) {
+
+      euler.set( beta, alpha, - gamma, 'YXZ' ); // 'ZXY' for the device, but 'YXZ' for us
+
+      quaternion.setFromEuler( euler ); // orient the device
+
+      quaternion.multiply( q1 ); // camera looks out the back of the device, not the top
+
+      quaternion.multiply( q0.setFromAxisAngle( zee, - orient ) ); // adjust for screen orientation
+
+    };
+
+  }();
+
+  this.connect = function () {
+ 
+    onScreenOrientationChangeEvent();
+
+    window.addEventListener( 'orientationchange', onScreenOrientationChangeEvent, false );
+    window.addEventListener( 'deviceorientation', onDeviceOrientationChangeEvent, false );
+
+    scope.enabled = true;
+
+  };
+
+  this.disconnect = function () {
+
+    window.removeEventListener( 'orientationchange', onScreenOrientationChangeEvent, false );
+    window.removeEventListener( 'deviceorientation', onDeviceOrientationChangeEvent, false );
+
+    scope.enabled = false;
+
+  };
+
+  this.update = function () {
+
+    if ( scope.enabled === false ) return;
+
+    var device = scope.deviceOrientation;
+
+    if ( device ) {
+
+      var alpha = device.alpha ? THREE.Math.degToRad( device.alpha ) + scope.alphaOffset : 0; // Z
+
+      var beta = device.beta ? THREE.Math.degToRad( device.beta ) : 0; // X'
+
+      var gamma = device.gamma ? THREE.Math.degToRad( device.gamma ) : 0; // Y''
+
+      var orient = scope.screenOrientation ? THREE.Math.degToRad( scope.screenOrientation ) : 0; // O
+      
+      // NW ORIENTATION SMOOTHING 
+
+      if(this.lastOrientation) {
+        alpha = this._getSmoothedAngle(alpha , this.lastOrientation.alpha, this.smoothingFactor);
+        beta = this._getSmoothedAngle(beta + (beta < 0 ? 360 : 0) , this.lastOrientation.beta, this.smoothingFactor);
+        gamma = this._getSmoothedAngle(gamma + (gamma < 0 ? 180 : 0) , this.lastOrientation.gamma, this.smoothingFactor, 180);
+
+        this.lastOrientation = {
+          alpha: alpha,
+          beta: beta,
+          gamma: gamma
+        };
+      } else {
+        this.lastOrientation = {
+          alpha: alpha,
+          beta: beta + (beta < 0 ? 360 : 0),
+          gamma: gamma + (gamma < 0 ? 180 :0)
+        };
+      }
+      // NW END ADDED CODE
+      setObjectQuaternion( scope.object.quaternion, alpha, beta, gamma, orient );
+
+    }
+
+
+  };
+
+  // NW ADDED 
+  // Orders two angles 
+  this._orderAngle = function (a, b, r = 360) {
+    if ((b > a && Math.abs(b - a) < r / 2) || (a > b && Math.abs(b - a) > r / 2)) {
+      return { lesser: a, greater: b };
+    } else { 
+      return { lesser: b, greater: a };
+    }
+  };
+
+  // NW ALSO ADDED THIS METHOD
+  // get a smoothed angle
+  this._getSmoothedAngle = function (a, b, k, r = 360) {
+    var angles = this._orderAngle(a,b,r);
+    var angleshift = angles.lesser;
+    var origGreater = angles.greater;
+    angles.lesser = 0;
+    angles.greater -= angleshift;
+    if(angles.greater < 0) angles.greater += r;
+    var newangle = origGreater == b ? (1 - k) * angles.greater + k * angles.lesser : k * angles.greater + (1 - k) * angles.lesser;
+    newangle += angleshift;
+    if(newangle >= r) newangle -= r;
+    return newangle;
+  };
+
+  this.dispose = function () {
+
+    scope.disconnect();
+
+  };
+
+  this.connect();
+
+};

--- a/aframe/src/location-based/arjs-look-controls.js
+++ b/aframe/src/location-based/arjs-look-controls.js
@@ -1,0 +1,487 @@
+// To avoid recalculation at every mouse movement tick
+var PI_2 = Math.PI / 2;
+
+
+/**
+ * look-controls. Update entity pose, factoring mouse, touch, and WebVR API data.
+ */
+
+/* NOTE that this is a modified version of A-Frame's look-controls to 
+ * allow exponential smoothing, for use in AR.js.
+ *
+ * Modifications Nick Whitelegg (nickw1 github)
+ */
+
+AFRAME.registerComponent('arjs-look-controls', {
+  dependencies: ['position', 'rotation'],
+
+  schema: {
+    enabled: {default: true},
+    magicWindowTrackingEnabled: {default: true},
+    pointerLockEnabled: {default: false},
+    reverseMouseDrag: {default: false},
+    reverseTouchDrag: {default: false},
+    touchEnabled: {default: true},
+    smoothingFactor: { type: 'number', default: 1 }
+  },
+
+  init: function () {
+    this.deltaYaw = 0;
+    this.previousHMDPosition = new THREE.Vector3();
+    this.hmdQuaternion = new THREE.Quaternion();
+    this.magicWindowAbsoluteEuler = new THREE.Euler();
+    this.magicWindowDeltaEuler = new THREE.Euler();
+    this.position = new THREE.Vector3();
+    this.magicWindowObject = new THREE.Object3D();
+    this.rotation = {};
+    this.deltaRotation = {};
+    this.savedPose = null;
+    this.pointerLocked = false;
+    this.setupMouseControls();
+    this.bindMethods();
+    this.previousMouseEvent = {};
+
+    this.setupMagicWindowControls();
+
+    // To save / restore camera pose
+    this.savedPose = {
+      position: new THREE.Vector3(),
+      rotation: new THREE.Euler()
+    };
+
+    // Call enter VR handler if the scene has entered VR before the event listeners attached.
+    if (this.el.sceneEl.is('vr-mode')) { this.onEnterVR(); }
+  },
+
+  setupMagicWindowControls: function () {
+    var magicWindowControls;
+    var data = this.data;
+
+    // Only on mobile devices and only enabled if DeviceOrientation permission has been granted.
+    if (AFRAME.utils.device.isMobile()) {
+      magicWindowControls = this.magicWindowControls = new ArjsDeviceOrientationControls(this.magicWindowObject);
+      if (typeof DeviceOrientationEvent !== 'undefined' && DeviceOrientationEvent.requestPermission) {
+        magicWindowControls.enabled = false;
+        if (this.el.sceneEl.components['device-orientation-permission-ui'].permissionGranted) {
+          magicWindowControls.enabled = data.magicWindowTrackingEnabled;
+        } else {
+          this.el.sceneEl.addEventListener('deviceorientationpermissiongranted', function () {
+            magicWindowControls.enabled = data.magicWindowTrackingEnabled;
+          });
+        }
+      }
+    }
+  },
+
+  update: function (oldData) {
+    var data = this.data;
+
+    // Disable grab cursor classes if no longer enabled.
+    if (data.enabled !== oldData.enabled) {
+      this.updateGrabCursor(data.enabled);
+    }
+
+    // Reset magic window eulers if tracking is disabled.
+    if (oldData && !data.magicWindowTrackingEnabled && oldData.magicWindowTrackingEnabled) {
+      this.magicWindowAbsoluteEuler.set(0, 0, 0);
+      this.magicWindowDeltaEuler.set(0, 0, 0);
+    }
+
+    // Pass on magic window tracking setting to magicWindowControls.
+    if (this.magicWindowControls) {
+      this.magicWindowControls.enabled = data.magicWindowTrackingEnabled;
+      this.magicWindowControls.smoothingFactor = data.smoothingFactor;
+    }
+
+    if (oldData && !data.pointerLockEnabled !== oldData.pointerLockEnabled) {
+      this.removeEventListeners();
+      this.addEventListeners();
+      if (this.pointerLocked) { this.exitPointerLock(); }
+    }
+  },
+
+  tick: function (t) {
+    var data = this.data;
+    if (!data.enabled) { return; }
+    this.updateOrientation();
+  },
+
+  play: function () {
+    this.addEventListeners();
+  },
+
+  pause: function () {
+    this.removeEventListeners();
+    if (this.pointerLocked) { this.exitPointerLock(); }
+  },
+
+  remove: function () {
+    this.removeEventListeners();
+    if (this.pointerLocked) { this.exitPointerLock(); }
+  },
+
+  bindMethods: function () {
+    this.onMouseDown = AFRAME.utils.bind(this.onMouseDown, this);
+    this.onMouseMove = AFRAME.utils.bind(this.onMouseMove, this);
+    this.onMouseUp = AFRAME.utils.bind(this.onMouseUp, this);
+    this.onTouchStart = AFRAME.utils.bind(this.onTouchStart, this);
+    this.onTouchMove = AFRAME.utils.bind(this.onTouchMove, this);
+    this.onTouchEnd = AFRAME.utils.bind(this.onTouchEnd, this);
+    this.onEnterVR = AFRAME.utils.bind(this.onEnterVR, this);
+    this.onExitVR = AFRAME.utils.bind(this.onExitVR, this);
+    this.onPointerLockChange = AFRAME.utils.bind(this.onPointerLockChange, this);
+    this.onPointerLockError = AFRAME.utils.bind(this.onPointerLockError, this);
+  },
+
+ /**
+  * Set up states and Object3Ds needed to store rotation data.
+  */
+  setupMouseControls: function () {
+    this.mouseDown = false;
+    this.pitchObject = new THREE.Object3D();
+    this.yawObject = new THREE.Object3D();
+    this.yawObject.position.y = 10;
+    this.yawObject.add(this.pitchObject);
+  },
+
+  /**
+   * Add mouse and touch event listeners to canvas.
+   */
+  addEventListeners: function () {
+    var sceneEl = this.el.sceneEl;
+    var canvasEl = sceneEl.canvas;
+
+    // Wait for canvas to load.
+    if (!canvasEl) {
+      sceneEl.addEventListener('render-target-loaded', AFRAME.utils.bind(this.addEventListeners, this));
+      return;
+    }
+
+    // Mouse events.
+    canvasEl.addEventListener('mousedown', this.onMouseDown, false);
+    window.addEventListener('mousemove', this.onMouseMove, false);
+    window.addEventListener('mouseup', this.onMouseUp, false);
+
+    // Touch events.
+    canvasEl.addEventListener('touchstart', this.onTouchStart);
+    window.addEventListener('touchmove', this.onTouchMove);
+    window.addEventListener('touchend', this.onTouchEnd);
+
+    // sceneEl events.
+    sceneEl.addEventListener('enter-vr', this.onEnterVR);
+    sceneEl.addEventListener('exit-vr', this.onExitVR);
+
+    // Pointer Lock events.
+    if (this.data.pointerLockEnabled) {
+      document.addEventListener('pointerlockchange', this.onPointerLockChange, false);
+      document.addEventListener('mozpointerlockchange', this.onPointerLockChange, false);
+      document.addEventListener('pointerlockerror', this.onPointerLockError, false);
+    }
+  },
+
+  /**
+   * Remove mouse and touch event listeners from canvas.
+   */
+  removeEventListeners: function () {
+    var sceneEl = this.el.sceneEl;
+    var canvasEl = sceneEl && sceneEl.canvas;
+
+    if (!canvasEl) { return; }
+
+    // Mouse events.
+    canvasEl.removeEventListener('mousedown', this.onMouseDown);
+    window.removeEventListener('mousemove', this.onMouseMove);
+    window.removeEventListener('mouseup', this.onMouseUp);
+
+    // Touch events.
+    canvasEl.removeEventListener('touchstart', this.onTouchStart);
+    window.removeEventListener('touchmove', this.onTouchMove);
+    window.removeEventListener('touchend', this.onTouchEnd);
+
+    // sceneEl events.
+    sceneEl.removeEventListener('enter-vr', this.onEnterVR);
+    sceneEl.removeEventListener('exit-vr', this.onExitVR);
+
+    // Pointer Lock events.
+    document.removeEventListener('pointerlockchange', this.onPointerLockChange, false);
+    document.removeEventListener('mozpointerlockchange', this.onPointerLockChange, false);
+    document.removeEventListener('pointerlockerror', this.onPointerLockError, false);
+  },
+
+  /**
+   * Update orientation for mobile, mouse drag, and headset.
+   * Mouse-drag only enabled if HMD is not active.
+   */
+  updateOrientation: (function () {
+    var poseMatrix = new THREE.Matrix4();
+
+    return function () {
+      var object3D = this.el.object3D;
+      var pitchObject = this.pitchObject;
+      var yawObject = this.yawObject;
+      var pose;
+      var sceneEl = this.el.sceneEl;
+
+      // In VR mode, THREE is in charge of updating the camera pose.
+      if (sceneEl.is('vr-mode') && sceneEl.checkHeadsetConnected()) {
+        // With WebXR THREE applies headset pose to the object3D matrixWorld internally.
+        // Reflect values back on position, rotation, scale for getAttribute to return the expected values.
+        if (sceneEl.hasWebXR) {
+          pose = sceneEl.renderer.xr.getCameraPose();
+          if (pose) {
+            poseMatrix.elements = pose.transform.matrix;
+            poseMatrix.decompose(object3D.position, object3D.rotation, object3D.scale);
+          }
+        }
+        return;
+      }
+
+      this.updateMagicWindowOrientation();
+
+      // On mobile, do camera rotation with touch events and sensors.
+      object3D.rotation.x = this.magicWindowDeltaEuler.x + pitchObject.rotation.x;
+      object3D.rotation.y = this.magicWindowDeltaEuler.y + yawObject.rotation.y;
+      object3D.rotation.z = this.magicWindowDeltaEuler.z;
+    };
+  })(),
+
+  updateMagicWindowOrientation: function () {
+    var magicWindowAbsoluteEuler = this.magicWindowAbsoluteEuler;
+    var magicWindowDeltaEuler = this.magicWindowDeltaEuler;
+    // Calculate magic window HMD quaternion.
+    if (this.magicWindowControls && this.magicWindowControls.enabled) {
+      this.magicWindowControls.update();
+      magicWindowAbsoluteEuler.setFromQuaternion(this.magicWindowObject.quaternion, 'YXZ');
+      if (!this.previousMagicWindowYaw && magicWindowAbsoluteEuler.y !== 0) {
+        this.previousMagicWindowYaw = magicWindowAbsoluteEuler.y;
+      }
+      if (this.previousMagicWindowYaw) {
+        magicWindowDeltaEuler.x = magicWindowAbsoluteEuler.x;
+        magicWindowDeltaEuler.y += magicWindowAbsoluteEuler.y - this.previousMagicWindowYaw;
+        magicWindowDeltaEuler.z = magicWindowAbsoluteEuler.z;
+        this.previousMagicWindowYaw = magicWindowAbsoluteEuler.y;
+      }
+    }
+  },
+
+  /**
+   * Translate mouse drag into rotation.
+   *
+   * Dragging up and down rotates the camera around the X-axis (yaw).
+   * Dragging left and right rotates the camera around the Y-axis (pitch).
+   */
+  onMouseMove: function (evt) {
+    var direction;
+    var movementX;
+    var movementY;
+    var pitchObject = this.pitchObject;
+    var previousMouseEvent = this.previousMouseEvent;
+    var yawObject = this.yawObject;
+
+    // Not dragging or not enabled.
+    if (!this.data.enabled || (!this.mouseDown && !this.pointerLocked)) { return; }
+
+    // Calculate delta.
+    if (this.pointerLocked) {
+      movementX = evt.movementX || evt.mozMovementX || 0;
+      movementY = evt.movementY || evt.mozMovementY || 0;
+    } else {
+      movementX = evt.screenX - previousMouseEvent.screenX;
+      movementY = evt.screenY - previousMouseEvent.screenY;
+    }
+    this.previousMouseEvent.screenX = evt.screenX;
+    this.previousMouseEvent.screenY = evt.screenY;
+
+    // Calculate rotation.
+    direction = this.data.reverseMouseDrag ? 1 : -1;
+    yawObject.rotation.y += movementX * 0.002 * direction;
+    pitchObject.rotation.x += movementY * 0.002 * direction;
+    pitchObject.rotation.x = Math.max(-PI_2, Math.min(PI_2, pitchObject.rotation.x));
+  },
+
+  /**
+   * Register mouse down to detect mouse drag.
+   */
+  onMouseDown: function (evt) {
+    var sceneEl = this.el.sceneEl;
+    if (!this.data.enabled || (sceneEl.is('vr-mode') && sceneEl.checkHeadsetConnected())) { return; }
+    // Handle only primary button.
+    if (evt.button !== 0) { return; }
+
+    var canvasEl = sceneEl && sceneEl.canvas;
+
+    this.mouseDown = true;
+    this.previousMouseEvent.screenX = evt.screenX;
+    this.previousMouseEvent.screenY = evt.screenY;
+    this.showGrabbingCursor();
+
+    if (this.data.pointerLockEnabled && !this.pointerLocked) {
+      if (canvasEl.requestPointerLock) {
+        canvasEl.requestPointerLock();
+      } else if (canvasEl.mozRequestPointerLock) {
+        canvasEl.mozRequestPointerLock();
+      }
+    }
+  },
+
+  /**
+   * Shows grabbing cursor on scene
+   */
+  showGrabbingCursor: function () {
+    this.el.sceneEl.canvas.style.cursor = 'grabbing';
+  },
+
+  /**
+   * Hides grabbing cursor on scene
+   */
+  hideGrabbingCursor: function () {
+    this.el.sceneEl.canvas.style.cursor = '';
+  },
+
+  /**
+   * Register mouse up to detect release of mouse drag.
+   */
+  onMouseUp: function () {
+    this.mouseDown = false;
+    this.hideGrabbingCursor();
+  },
+
+  /**
+   * Register touch down to detect touch drag.
+   */
+  onTouchStart: function (evt) {
+    if (evt.touches.length !== 1 ||
+        !this.data.touchEnabled ||
+        this.el.sceneEl.is('vr-mode')) { return; }
+    this.touchStart = {
+      x: evt.touches[0].pageX,
+      y: evt.touches[0].pageY
+    };
+    this.touchStarted = true;
+  },
+
+  /**
+   * Translate touch move to Y-axis rotation.
+   */
+  onTouchMove: function (evt) {
+    var direction;
+    var canvas = this.el.sceneEl.canvas;
+    var deltaY;
+    var yawObject = this.yawObject;
+
+    if (!this.touchStarted || !this.data.touchEnabled) { return; }
+
+    deltaY = 2 * Math.PI * (evt.touches[0].pageX - this.touchStart.x) / canvas.clientWidth;
+
+    direction = this.data.reverseTouchDrag ? 1 : -1;
+    // Limit touch orientaion to to yaw (y axis).
+    yawObject.rotation.y -= deltaY * 0.5 * direction;
+    this.touchStart = {
+      x: evt.touches[0].pageX,
+      y: evt.touches[0].pageY
+    };
+  },
+
+  /**
+   * Register touch end to detect release of touch drag.
+   */
+  onTouchEnd: function () {
+    this.touchStarted = false;
+  },
+
+  /**
+   * Save pose.
+   */
+  onEnterVR: function () {
+    var sceneEl = this.el.sceneEl;
+    if (!sceneEl.checkHeadsetConnected()) { return; }
+    this.saveCameraPose();
+    this.el.object3D.position.set(0, 0, 0);
+    this.el.object3D.rotation.set(0, 0, 0);
+    if (sceneEl.hasWebXR) {
+      this.el.object3D.matrixAutoUpdate = false;
+      this.el.object3D.updateMatrix();
+    }
+  },
+
+  /**
+   * Restore the pose.
+   */
+  onExitVR: function () {
+    if (!this.el.sceneEl.checkHeadsetConnected()) { return; }
+    this.restoreCameraPose();
+    this.previousHMDPosition.set(0, 0, 0);
+    this.el.object3D.matrixAutoUpdate = true;
+  },
+
+  /**
+   * Update Pointer Lock state.
+   */
+  onPointerLockChange: function () {
+    this.pointerLocked = !!(document.pointerLockElement || document.mozPointerLockElement);
+  },
+
+  /**
+   * Recover from Pointer Lock error.
+   */
+  onPointerLockError: function () {
+    this.pointerLocked = false;
+  },
+
+  // Exits pointer-locked mode.
+  exitPointerLock: function () {
+    document.exitPointerLock();
+    this.pointerLocked = false;
+  },
+
+  /**
+   * Toggle the feature of showing/hiding the grab cursor.
+   */
+  updateGrabCursor: function (enabled) {
+    var sceneEl = this.el.sceneEl;
+
+    function enableGrabCursor () { sceneEl.canvas.classList.add('a-grab-cursor'); }
+    function disableGrabCursor () { sceneEl.canvas.classList.remove('a-grab-cursor'); }
+
+    if (!sceneEl.canvas) {
+      if (enabled) {
+        sceneEl.addEventListener('render-target-loaded', enableGrabCursor);
+      } else {
+        sceneEl.addEventListener('render-target-loaded', disableGrabCursor);
+      }
+      return;
+    }
+
+    if (enabled) {
+      enableGrabCursor();
+      return;
+    }
+    disableGrabCursor();
+  },
+
+  /**
+   * Save camera pose before entering VR to restore later if exiting.
+   */
+  saveCameraPose: function () {
+    var el = this.el;
+
+    this.savedPose.position.copy(el.object3D.position);
+    this.savedPose.rotation.copy(el.object3D.rotation);
+    this.hasSavedPose = true;
+  },
+
+  /**
+   * Reset camera pose to before entering VR.
+   */
+  restoreCameraPose: function () {
+    var el = this.el;
+    var savedPose = this.savedPose;
+
+    if (!this.hasSavedPose) { return; }
+
+    // Reset camera orientation.
+    el.object3D.position.copy(savedPose.position);
+    el.object3D.rotation.copy(savedPose.rotation);
+    this.hasSavedPose = false;
+  }
+});

--- a/aframe/src/location-based/gps-camera.js
+++ b/aframe/src/location-based/gps-camera.js
@@ -65,7 +65,7 @@ AFRAME.registerComponent('gps-camera', {
         }
     },
     init: function () {
-        if (!this.el.components['look-controls']) {
+        if (!this.el.components['arjs-look-controls']) {
             return;
         }
 
@@ -88,7 +88,7 @@ AFRAME.registerComponent('gps-camera', {
             }
         }.bind(this));
 
-        this.lookControls = this.el.components['look-controls'];
+        this.lookControls = this.el.components['arjs-look-controls'];
 
         // listen to deviceorientation event
         var eventName = this._getDeviceOrientationEventName();

--- a/aframe/src/location-based/gps-camera.js
+++ b/aframe/src/location-based/gps-camera.js
@@ -65,7 +65,7 @@ AFRAME.registerComponent('gps-camera', {
         }
     },
     init: function () {
-        if (!this.el.components['arjs-look-controls']) {
+        if (!this.el.components['arjs-look-controls'] && !this.el.components['look-controls']) {
             return;
         }
 
@@ -88,7 +88,7 @@ AFRAME.registerComponent('gps-camera', {
             }
         }.bind(this));
 
-        this.lookControls = this.el.components['arjs-look-controls'];
+        this.lookControls = this.el.components['arjs-look-controls'] || this.el.components['look-controls'];
 
         // listen to deviceorientation event
         var eventName = this._getDeviceOrientationEventName();

--- a/aframe/src/location-based/gps-projected-camera.js
+++ b/aframe/src/location-based/gps-projected-camera.js
@@ -83,7 +83,7 @@ AFRAME.registerComponent('gps-projected-camera', {
         }
     },
     init: function() {
-        if (!this.el.components['look-controls']) {
+        if (!this.el.components['arjs-look-controls']) {
             return;
         }
 
@@ -106,7 +106,7 @@ AFRAME.registerComponent('gps-projected-camera', {
             }
         }.bind(this));
 
-        this.lookControls = this.el.components['look-controls'];
+        this.lookControls = this.el.components['arjs-look-controls'];
 
         // listen to deviceorientation event
         var eventName = this._getDeviceOrientationEventName();

--- a/aframe/src/location-based/gps-projected-camera.js
+++ b/aframe/src/location-based/gps-projected-camera.js
@@ -83,7 +83,7 @@ AFRAME.registerComponent('gps-projected-camera', {
         }
     },
     init: function() {
-        if (!this.el.components['arjs-look-controls']) {
+        if (!this.el.components['arjs-look-controls'] && !this.el.components['look-controls']) {
             return;
         }
 
@@ -106,7 +106,7 @@ AFRAME.registerComponent('gps-projected-camera', {
             }
         }.bind(this));
 
-        this.lookControls = this.el.components['arjs-look-controls'];
+        this.lookControls = this.el.components['arjs-look-controls'] || this.el.components['look-controls'];
 
         // listen to deviceorientation event
         var eventName = this._getDeviceOrientationEventName();


### PR DESCRIPTION
<!-- Please, don't delete this template or we'll close your issue -->

**⚠️ All PRs have to be done versus 'dev' branch, so be aware of that, or we'll close your issue ⚠️**

**What kind of change does this PR introduce?**
<!-- Can be a new feature, a bugfix, or refactoring, etc -->
Feature; considerably reduces the shaking effect when holding device still. 

**Can it be referenced to an Issue? If so what is the issue # ?**
#139 

**How can we test it?**
<!-- All information can be found about our tests in https://github.com/jeromeetienne/AR.js/blob/master/test/TODO.md -->
<!-- At the moment we don't explicitly require tests, because it's not streamlined yet -->
Note that you cannot use the `<a-camera>` tag as this automatically injects the default `look-controls`. So you hace to create an `<a-entity>` with a `camera` component, as well as `arjs-look-controls`.

So for example:
`<a-entity id='camera1' camera='near:0.1; far:50000; fov:80;' arjs-look-controls='smoothingFactor: 0.1' gps-projected-camera='gpsMinDistance: 5' ... >`
**Summary**
<!-- State here what problem the PR solves and what is the proposed solution -->

Considerably reduces the shaking effect when holding device still. It does this by applying smoothing to the raw orientation values.

To do this, I created a custom `look-controls` component entitled `arjs-look-controls` to replace the default one. This approach is recommended in the A-Frame documentation, see [here](https://aframe.io/docs/1.0.0/components/look-controls.html). The component uses `THREE.DeviceOrientationControls` which itself has been modified to add smoothing. The `arjs-look-controls` component has a `smoothingFactor` property to control the amount of smoothing.

A smoothed orientation is essentially defined by:
`smoothedOrientation  = smoothingFactor * currentValue + (1-smoothingFactor) * previousSmoothedValue`

so it can be seen that the lower the smoothing factor (in range 0 to 1), the more smoothing applies. In tests 0.1 seems to work well whereas 0.05 smooths a little too much.

**Does this PR introduce a breaking change?**

No. Code to test for `arjs-look-controls` has been added to `gps-camera` and `gps-projected-camera` but it falls back to `look-controls` if not available.

**Please TEST your PR before proposing it. Specify here what device you have used for tests, version of OS and version of Browser**

Pixel 3, Android 10, Chrome.

**Other information**
