### PR TITLE
Allow minDistance and maxDistance to work with simulated GPS position

### DIFF
--- a/aframe/build/aframe-ar-location-only.js
+++ b/aframe/build/aframe-ar-location-only.js
@@ -816,25 +816,28 @@ AFRAME.registerComponent('gps-camera', {
     },
 
     play: function() {
-        this._watchPositionId = this._initWatchGPS(function (position) {
-            var localPosition = {
-                latitude: position.coords.latitude,
-                longitude: position.coords.longitude,
-                altitude: position.coords.altitude,
-                accuracy: position.coords.accuracy,
-                altitudeAccuracy: position.coords.altitudeAccuracy,
-            };
-          
+        if (this.data.simulateLatitude !== 0 && this.data.simulateLongitude !== 0) {
+            localPosition.latitude = this.data.simulateLatitude;
+            localPosition.longitude = this.data.simulateLongitude;
             if (this.data.simulateAltitude !== 0) {
                 localPosition.altitude = this.data.simulateAltitude;
             }
+            this.currentCoords = localPosition;
+            this._updatePosition();
+        } else {
+            this._watchPositionId = this._initWatchGPS(function (position) {
+                var localPosition = {
+                    latitude: position.coords.latitude,
+                    longitude: position.coords.longitude,
+                    altitude: position.coords.altitude,
+                    accuracy: position.coords.accuracy,
+                    altitudeAccuracy: position.coords.altitudeAccuracy,
+                };
+          
+                if (this.data.simulateAltitude !== 0) {
+                    localPosition.altitude = this.data.simulateAltitude;
+                }
                
-            if (this.data.simulateLatitude !== 0 && this.data.simulateLongitude !== 0) {
-                localPosition.latitude = this.data.simulateLatitude;
-                localPosition.longitude = this.data.simulateLongitude;
-                this.currentCoords = localPosition;
-                this._updatePosition();
-            } else {
                 this.currentCoords = localPosition;
                 var distMoved = this._haversineDist(
                     this.lastPosition,
@@ -848,8 +851,8 @@ AFRAME.registerComponent('gps-camera', {
                         latitude: this.currentCoords.latitude
                     };
                 }
-            }
-        }.bind(this));
+            }.bind(this));
+        }
     },
 
     tick: function () {
@@ -1017,7 +1020,7 @@ AFRAME.registerComponent('gps-camera', {
         if (isPlace && this.data.maxDistance && this.data.maxDistance > 0 && distance > this.data.maxDistance) {
             return Number.MAX_SAFE_INTEGER;
         }
-
+	
         return distance;
     },
 

--- a/aframe/build/aframe-ar-location-only.js
+++ b/aframe/build/aframe-ar-location-only.js
@@ -1383,26 +1383,29 @@ AFRAME.registerComponent('gps-projected-camera', {
         window.addEventListener(eventName, this._onDeviceOrientation, false);
     },
 
-    play: function() { 
-        this._watchPositionId = this._initWatchGPS(function (position) {
-           var localPosition = {
-                latitude: position.coords.latitude,
-                longitude: position.coords.longitude,
-                altitude: position.coords.altitude,
-                accuracy: position.coords.accuracy,
-                altitudeAccuracy: position.coords.altitudeAccuracy,
-            };
-          
+    play: function() {
+        if (this.data.simulateLatitude !== 0 && this.data.simulateLongitude !== 0) {
+            localPosition.latitude = this.data.simulateLatitude;
+            localPosition.longitude = this.data.simulateLongitude;
             if (this.data.simulateAltitude !== 0) {
                 localPosition.altitude = this.data.simulateAltitude;
             }
+            this.currentCoords = localPosition;
+            this._updatePosition();
+        } else {
+            this._watchPositionId = this._initWatchGPS(function (position) {
+                var localPosition = {
+                    latitude: position.coords.latitude,
+                    longitude: position.coords.longitude,
+                    altitude: position.coords.altitude,
+                    accuracy: position.coords.accuracy,
+                    altitudeAccuracy: position.coords.altitudeAccuracy,
+                };
+          
+                if (this.data.simulateAltitude !== 0) {
+                    localPosition.altitude = this.data.simulateAltitude;
+                }
                
-            if (this.data.simulateLatitude !== 0 && this.data.simulateLongitude !== 0) {
-                localPosition.latitude = this.data.simulateLatitude;
-                localPosition.longitude = this.data.simulateLongitude;
-                this.currentCoords = localPosition;
-                this._updatePosition();
-            } else {
                 this.currentCoords = localPosition;
                 var distMoved = this._haversineDist(
                     this.lastPosition,
@@ -1416,8 +1419,8 @@ AFRAME.registerComponent('gps-projected-camera', {
                         latitude: this.currentCoords.latitude
                     };
                 }
-            }
-        }.bind(this));
+            }.bind(this));
+        }
     },
 
     tick: function() {

--- a/aframe/build/aframe-ar-nft.js
+++ b/aframe/build/aframe-ar-nft.js
@@ -4780,25 +4780,28 @@ AFRAME.registerComponent('gps-camera', {
     },
 
     play: function() {
-        this._watchPositionId = this._initWatchGPS(function (position) {
-            var localPosition = {
-                latitude: position.coords.latitude,
-                longitude: position.coords.longitude,
-                altitude: position.coords.altitude,
-                accuracy: position.coords.accuracy,
-                altitudeAccuracy: position.coords.altitudeAccuracy,
-            };
-          
+        if (this.data.simulateLatitude !== 0 && this.data.simulateLongitude !== 0) {
+            localPosition.latitude = this.data.simulateLatitude;
+            localPosition.longitude = this.data.simulateLongitude;
             if (this.data.simulateAltitude !== 0) {
                 localPosition.altitude = this.data.simulateAltitude;
             }
+            this.currentCoords = localPosition;
+            this._updatePosition();
+        } else {
+            this._watchPositionId = this._initWatchGPS(function (position) {
+                var localPosition = {
+                    latitude: position.coords.latitude,
+                    longitude: position.coords.longitude,
+                    altitude: position.coords.altitude,
+                    accuracy: position.coords.accuracy,
+                    altitudeAccuracy: position.coords.altitudeAccuracy,
+                };
+          
+                if (this.data.simulateAltitude !== 0) {
+                    localPosition.altitude = this.data.simulateAltitude;
+                }
                
-            if (this.data.simulateLatitude !== 0 && this.data.simulateLongitude !== 0) {
-                localPosition.latitude = this.data.simulateLatitude;
-                localPosition.longitude = this.data.simulateLongitude;
-                this.currentCoords = localPosition;
-                this._updatePosition();
-            } else {
                 this.currentCoords = localPosition;
                 var distMoved = this._haversineDist(
                     this.lastPosition,
@@ -4812,8 +4815,8 @@ AFRAME.registerComponent('gps-camera', {
                         latitude: this.currentCoords.latitude
                     };
                 }
-            }
-        }.bind(this));
+            }.bind(this));
+        }
     },
 
     tick: function () {
@@ -4981,7 +4984,7 @@ AFRAME.registerComponent('gps-camera', {
         if (isPlace && this.data.maxDistance && this.data.maxDistance > 0 && distance > this.data.maxDistance) {
             return Number.MAX_SAFE_INTEGER;
         }
-
+	
         return distance;
     },
 

--- a/aframe/build/aframe-ar-nft.js
+++ b/aframe/build/aframe-ar-nft.js
@@ -5347,26 +5347,29 @@ AFRAME.registerComponent('gps-projected-camera', {
         window.addEventListener(eventName, this._onDeviceOrientation, false);
     },
 
-    play: function() { 
-        this._watchPositionId = this._initWatchGPS(function (position) {
-           var localPosition = {
-                latitude: position.coords.latitude,
-                longitude: position.coords.longitude,
-                altitude: position.coords.altitude,
-                accuracy: position.coords.accuracy,
-                altitudeAccuracy: position.coords.altitudeAccuracy,
-            };
-          
+    play: function() {
+        if (this.data.simulateLatitude !== 0 && this.data.simulateLongitude !== 0) {
+            localPosition.latitude = this.data.simulateLatitude;
+            localPosition.longitude = this.data.simulateLongitude;
             if (this.data.simulateAltitude !== 0) {
                 localPosition.altitude = this.data.simulateAltitude;
             }
+            this.currentCoords = localPosition;
+            this._updatePosition();
+        } else {
+            this._watchPositionId = this._initWatchGPS(function (position) {
+                var localPosition = {
+                    latitude: position.coords.latitude,
+                    longitude: position.coords.longitude,
+                    altitude: position.coords.altitude,
+                    accuracy: position.coords.accuracy,
+                    altitudeAccuracy: position.coords.altitudeAccuracy,
+                };
+          
+                if (this.data.simulateAltitude !== 0) {
+                    localPosition.altitude = this.data.simulateAltitude;
+                }
                
-            if (this.data.simulateLatitude !== 0 && this.data.simulateLongitude !== 0) {
-                localPosition.latitude = this.data.simulateLatitude;
-                localPosition.longitude = this.data.simulateLongitude;
-                this.currentCoords = localPosition;
-                this._updatePosition();
-            } else {
                 this.currentCoords = localPosition;
                 var distMoved = this._haversineDist(
                     this.lastPosition,
@@ -5380,8 +5383,8 @@ AFRAME.registerComponent('gps-projected-camera', {
                         latitude: this.currentCoords.latitude
                     };
                 }
-            }
-        }.bind(this));
+            }.bind(this));
+        }
     },
 
     tick: function() {

--- a/aframe/build/aframe-ar.js
+++ b/aframe/build/aframe-ar.js
@@ -6151,25 +6151,28 @@ AFRAME.registerComponent('gps-camera', {
     },
 
     play: function() {
-        this._watchPositionId = this._initWatchGPS(function (position) {
-            var localPosition = {
-                latitude: position.coords.latitude,
-                longitude: position.coords.longitude,
-                altitude: position.coords.altitude,
-                accuracy: position.coords.accuracy,
-                altitudeAccuracy: position.coords.altitudeAccuracy,
-            };
-          
+        if (this.data.simulateLatitude !== 0 && this.data.simulateLongitude !== 0) {
+            localPosition.latitude = this.data.simulateLatitude;
+            localPosition.longitude = this.data.simulateLongitude;
             if (this.data.simulateAltitude !== 0) {
                 localPosition.altitude = this.data.simulateAltitude;
             }
+            this.currentCoords = localPosition;
+            this._updatePosition();
+        } else {
+            this._watchPositionId = this._initWatchGPS(function (position) {
+                var localPosition = {
+                    latitude: position.coords.latitude,
+                    longitude: position.coords.longitude,
+                    altitude: position.coords.altitude,
+                    accuracy: position.coords.accuracy,
+                    altitudeAccuracy: position.coords.altitudeAccuracy,
+                };
+          
+                if (this.data.simulateAltitude !== 0) {
+                    localPosition.altitude = this.data.simulateAltitude;
+                }
                
-            if (this.data.simulateLatitude !== 0 && this.data.simulateLongitude !== 0) {
-                localPosition.latitude = this.data.simulateLatitude;
-                localPosition.longitude = this.data.simulateLongitude;
-                this.currentCoords = localPosition;
-                this._updatePosition();
-            } else {
                 this.currentCoords = localPosition;
                 var distMoved = this._haversineDist(
                     this.lastPosition,
@@ -6183,8 +6186,8 @@ AFRAME.registerComponent('gps-camera', {
                         latitude: this.currentCoords.latitude
                     };
                 }
-            }
-        }.bind(this));
+            }.bind(this));
+        }
     },
 
     tick: function () {
@@ -6352,7 +6355,7 @@ AFRAME.registerComponent('gps-camera', {
         if (isPlace && this.data.maxDistance && this.data.maxDistance > 0 && distance > this.data.maxDistance) {
             return Number.MAX_SAFE_INTEGER;
         }
-
+	
         return distance;
     },
 

--- a/aframe/build/aframe-ar.js
+++ b/aframe/build/aframe-ar.js
@@ -6718,26 +6718,29 @@ AFRAME.registerComponent('gps-projected-camera', {
         window.addEventListener(eventName, this._onDeviceOrientation, false);
     },
 
-    play: function() { 
-        this._watchPositionId = this._initWatchGPS(function (position) {
-           var localPosition = {
-                latitude: position.coords.latitude,
-                longitude: position.coords.longitude,
-                altitude: position.coords.altitude,
-                accuracy: position.coords.accuracy,
-                altitudeAccuracy: position.coords.altitudeAccuracy,
-            };
-          
+    play: function() {
+        if (this.data.simulateLatitude !== 0 && this.data.simulateLongitude !== 0) {
+            localPosition.latitude = this.data.simulateLatitude;
+            localPosition.longitude = this.data.simulateLongitude;
             if (this.data.simulateAltitude !== 0) {
                 localPosition.altitude = this.data.simulateAltitude;
             }
+            this.currentCoords = localPosition;
+            this._updatePosition();
+        } else {
+            this._watchPositionId = this._initWatchGPS(function (position) {
+                var localPosition = {
+                    latitude: position.coords.latitude,
+                    longitude: position.coords.longitude,
+                    altitude: position.coords.altitude,
+                    accuracy: position.coords.accuracy,
+                    altitudeAccuracy: position.coords.altitudeAccuracy,
+                };
+          
+                if (this.data.simulateAltitude !== 0) {
+                    localPosition.altitude = this.data.simulateAltitude;
+                }
                
-            if (this.data.simulateLatitude !== 0 && this.data.simulateLongitude !== 0) {
-                localPosition.latitude = this.data.simulateLatitude;
-                localPosition.longitude = this.data.simulateLongitude;
-                this.currentCoords = localPosition;
-                this._updatePosition();
-            } else {
                 this.currentCoords = localPosition;
                 var distMoved = this._haversineDist(
                     this.lastPosition,
@@ -6751,8 +6754,8 @@ AFRAME.registerComponent('gps-projected-camera', {
                         latitude: this.currentCoords.latitude
                     };
                 }
-            }
-        }.bind(this));
+            }.bind(this));
+        }
     },
 
     tick: function() {

--- a/aframe/examples/location-based/max-min-distance/index.html
+++ b/aframe/examples/location-based/max-min-distance/index.html
@@ -9,20 +9,19 @@
 
 </head>
 
-<body style='margin: 0; overflow: hidden;'>
+<body><!-- style='margin: 0; overflow: hidden;'>-->
     <a-scene
         vr-mode-ui="enabled: false"
-		embedded
-		arjs='sourceType: webcam; debugUIEnabled: false;'>
+		arjs='sourceType: webcam; videoTexture: true; debugUIEnabled: false;'>
 
         <!-- too near, is like 2m far -->
-        <a-box material="color: red;" scale="15 15 15" gps-entity-place="latitude: 44.504493; longitude: 11.301134;"></a-box>
+        <a-box material="color: red;" scale="25 25 25" gps-entity-place="latitude: 44.504493; longitude: 11.301134;"></a-box>
 
         <!-- visible, is like 400m far -->
-        <a-box material="color: yellow;" scale="15 15 15" gps-entity-place="latitude: 44.506477; longitude: 11.301524;"></a-box>
+        <a-box material="color: yellow;" scale="25 25 25" gps-entity-place="latitude: 44.506477; longitude: 11.301524;"></a-box>
 
         <!-- too far, is like 2.5km far -->
-        <a-box material="color: green;" scale="15 15 15" gps-entity-place="latitude: 44.500013; longitude: 11.277351;"></a-box>
+        <a-box material="color: green;" scale="25 25 25" gps-entity-place="latitude: 44.500013; longitude: 11.277351;"></a-box>
 
         <a-camera
             rotation-reader

--- a/aframe/src/location-based/gps-camera.js
+++ b/aframe/src/location-based/gps-camera.js
@@ -115,25 +115,28 @@ AFRAME.registerComponent('gps-camera', {
     },
 
     play: function() {
-        this._watchPositionId = this._initWatchGPS(function (position) {
-            var localPosition = {
-                latitude: position.coords.latitude,
-                longitude: position.coords.longitude,
-                altitude: position.coords.altitude,
-                accuracy: position.coords.accuracy,
-                altitudeAccuracy: position.coords.altitudeAccuracy,
-            };
-          
+        if (this.data.simulateLatitude !== 0 && this.data.simulateLongitude !== 0) {
+            localPosition.latitude = this.data.simulateLatitude;
+            localPosition.longitude = this.data.simulateLongitude;
             if (this.data.simulateAltitude !== 0) {
                 localPosition.altitude = this.data.simulateAltitude;
             }
+            this.currentCoords = localPosition;
+            this._updatePosition();
+        } else {
+            this._watchPositionId = this._initWatchGPS(function (position) {
+                var localPosition = {
+                    latitude: position.coords.latitude,
+                    longitude: position.coords.longitude,
+                    altitude: position.coords.altitude,
+                    accuracy: position.coords.accuracy,
+                    altitudeAccuracy: position.coords.altitudeAccuracy,
+                };
+          
+                if (this.data.simulateAltitude !== 0) {
+                    localPosition.altitude = this.data.simulateAltitude;
+                }
                
-            if (this.data.simulateLatitude !== 0 && this.data.simulateLongitude !== 0) {
-                localPosition.latitude = this.data.simulateLatitude;
-                localPosition.longitude = this.data.simulateLongitude;
-                this.currentCoords = localPosition;
-                this._updatePosition();
-            } else {
                 this.currentCoords = localPosition;
                 var distMoved = this._haversineDist(
                     this.lastPosition,
@@ -147,8 +150,8 @@ AFRAME.registerComponent('gps-camera', {
                         latitude: this.currentCoords.latitude
                     };
                 }
-            }
-        }.bind(this));
+            }.bind(this));
+        }
     },
 
     tick: function () {
@@ -316,7 +319,7 @@ AFRAME.registerComponent('gps-camera', {
         if (isPlace && this.data.maxDistance && this.data.maxDistance > 0 && distance > this.data.maxDistance) {
             return Number.MAX_SAFE_INTEGER;
         }
-
+	
         return distance;
     },
 

--- a/aframe/src/location-based/gps-projected-camera.js
+++ b/aframe/src/location-based/gps-projected-camera.js
@@ -131,26 +131,29 @@ AFRAME.registerComponent('gps-projected-camera', {
         window.addEventListener(eventName, this._onDeviceOrientation, false);
     },
 
-    play: function() { 
-        this._watchPositionId = this._initWatchGPS(function (position) {
-           var localPosition = {
-                latitude: position.coords.latitude,
-                longitude: position.coords.longitude,
-                altitude: position.coords.altitude,
-                accuracy: position.coords.accuracy,
-                altitudeAccuracy: position.coords.altitudeAccuracy,
-            };
-          
+    play: function() {
+        if (this.data.simulateLatitude !== 0 && this.data.simulateLongitude !== 0) {
+            localPosition.latitude = this.data.simulateLatitude;
+            localPosition.longitude = this.data.simulateLongitude;
             if (this.data.simulateAltitude !== 0) {
                 localPosition.altitude = this.data.simulateAltitude;
             }
+            this.currentCoords = localPosition;
+            this._updatePosition();
+        } else {
+            this._watchPositionId = this._initWatchGPS(function (position) {
+                var localPosition = {
+                    latitude: position.coords.latitude,
+                    longitude: position.coords.longitude,
+                    altitude: position.coords.altitude,
+                    accuracy: position.coords.accuracy,
+                    altitudeAccuracy: position.coords.altitudeAccuracy,
+                };
+          
+                if (this.data.simulateAltitude !== 0) {
+                    localPosition.altitude = this.data.simulateAltitude;
+                }
                
-            if (this.data.simulateLatitude !== 0 && this.data.simulateLongitude !== 0) {
-                localPosition.latitude = this.data.simulateLatitude;
-                localPosition.longitude = this.data.simulateLongitude;
-                this.currentCoords = localPosition;
-                this._updatePosition();
-            } else {
                 this.currentCoords = localPosition;
                 var distMoved = this._haversineDist(
                     this.lastPosition,
@@ -164,8 +167,8 @@ AFRAME.registerComponent('gps-projected-camera', {
                         latitude: this.currentCoords.latitude
                     };
                 }
-            }
-        }.bind(this));
+            }.bind(this));
+        }
     },
 
     tick: function() {


### PR DESCRIPTION
<!-- Please, don't delete this template or we'll close your issue -->

**⚠️ All PRs have to be done versus 'dev' branch, so be aware of that, or we'll close your issue ⚠️**

**What kind of change does this PR introduce?**
<!-- Can be a new feature, a bugfix, or refactoring, etc -->

Currently, the `max-min-distance` location-based example does not work if a simulated location is used. This appears to be due to the fact that GPS listening is setup even if a simulated location is provided. This PR prevents GPS listening from starting if a simulated location is used.

**Can it be referenced to an Issue? If so what is the issue # ?**

n/a

**How can we test it?**
<!-- All information can be found about our tests in https://github.com/jeromeetienne/AR.js/blob/master/test/TODO.md -->
<!-- At the moment we don't explicitly require tests, because it's not streamlined yet -->

Test using the `max-min-distance` example, or any example making use of `gps-camera`'s `minDistance` and `maxDistance` properties, using a simulated location.

**Summary**
<!-- State here what problem the PR solves and what is the proposed solution -->

**Does this PR introduce a breaking change?**

No

**Please TEST your PR before proposing it. Specify here what device you have used for tests, version of OS and version of Browser**

Firefox latest, Ubuntu 18.04

**Other information**
