### PR TITLE
Change use of alert() to appending HTML div to display error messages

### DIFF
--- a/aframe/build/aframe-ar-nft.js
+++ b/aframe/build/aframe-ar-nft.js
@@ -1628,7 +1628,12 @@ ARjs.Source.prototype._initSourceWebcam = function (onReady, onError) {
         window.dispatchEvent(event);
 
         setTimeout(() => {
-            alert('Webcam Error\nName: ' + error.name + '\nMessage: ' + error.message)
+            if (!document.getElementById('error-popup')) {
+                var errorPopup = document.createElement('div');
+                errorPopup.innerHTML = 'Webcam Error\nName: ' + error.name + '\nMessage: ' + error.message
+                errorPopup.setAttribute('id', 'error-popup');
+                document.body.appendChild(errorPopup);
+            }
         }, 1000);
     }
 
@@ -1739,7 +1744,12 @@ ARjs.Source.prototype.toggleMobileTorch = function () {
 
     var stream = arToolkitSource.domElement.srcObject
     if (stream instanceof MediaStream === false) {
-        alert('enabling mobile torch is available only on webcam')
+        if (!document.getElementById('error-popup')) {
+            var errorPopup = document.createElement('div');
+            errorPopup.innerHTML = 'enabling mobile torch is available only on webcam'
+            errorPopup.setAttribute('id', 'error-popup');
+            document.body.appendChild(errorPopup);
+        }
         return
     }
 
@@ -1751,7 +1761,12 @@ ARjs.Source.prototype.toggleMobileTorch = function () {
     var capabilities = videoTrack.getCapabilities()
 
     if (!capabilities.torch) {
-        alert('no mobile torch is available on your camera')
+        if (!document.getElementById('error-popup')) {
+            var errorPopup = document.createElement('div');
+            errorPopup.innerHTML = 'no mobile torch is available on your camera'
+            errorPopup.setAttribute('id', 'error-popup');
+            document.body.appendChild(errorPopup);
+        }
         return
     }
 
@@ -4639,9 +4654,20 @@ AFRAME.registerComponent('arjs-webcam-texture', {
                 this.video.srcObject = stream;    
                 this.video.play();
             })
-            .catch(e => { alert(`Webcam error: ${e}`); });
+            .catch(e => {  
+                if (!document.getElementById('error-popup')) {
+                    var errorPopup = document.createElement('div');
+                    errorPopup.innerHTML = `Webcam error: ${e}`
+                    errorPopup.setAttribute('id', 'error-popup');
+                    document.body.appendChild(errorPopup);
+                } });
         } else {
-            alert('sorry - media devices API not supported');
+            if (!document.getElementById('error-popup')) {
+                var errorPopup = document.createElement('div');
+                errorPopup.innerHTML = 'sorry - media devices API not supported'
+                errorPopup.setAttribute('id', 'error-popup');
+                document.body.appendChild(errorPopup);
+            }
         }
     },
 
@@ -4764,10 +4790,20 @@ AFRAME.registerComponent('gps-camera', {
 
                 document.addEventListener('touchend', function () { handler() }, false);
 
-                alert('After camera permission prompt, please tap the screen to activate geolocation.');
+                if (!document.getElementById('error-popup')) {
+                    var errorPopup = document.createElement('div');
+                    errorPopup.innerHTML = 'After camera permission prompt, please tap the screen to activate geolocation.'
+                    errorPopup.setAttribute('id', 'error-popup');
+                    document.body.appendChild(errorPopup);
+                }    
             } else {
                 var timeout = setTimeout(function () {
-                    alert('Please enable device orientation in Settings > Safari > Motion & Orientation Access.')
+                    if (!document.getElementById('error-popup')) {
+                        var errorPopup = document.createElement('div');
+                        errorPopup.innerHTML = 'Please enable device orientation in Settings > Safari > Motion & Orientation Access.'
+                        errorPopup.setAttribute('id', 'error-popup');
+                        document.body.appendChild(errorPopup);
+                    }
                 }, 750);
                 window.addEventListener(eventName, function () {
                     clearTimeout(timeout);
@@ -4869,12 +4905,22 @@ AFRAME.registerComponent('gps-camera', {
 
                 if (err.code === 1) {
                     // User denied GeoLocation, let their know that
-                    alert('Please activate Geolocation and refresh the page. If it is already active, please check permissions for this website.');
+                    if (!document.getElementById('error-popup')) {
+                        var errorPopup = document.createElement('div');
+                        errorPopup.innerHTML = 'Please activate Geolocation and refresh the page. If it is already active, please check permissions for this website.'
+                        errorPopup.setAttribute('id', 'error-popup');
+                        document.body.appendChild(errorPopup);
+                    }
                     return;
                 }
 
                 if (err.code === 3) {
-                    alert('Cannot retrieve GPS position. Signal is absent.');
+                    if (!document.getElementById('error-popup')) {
+                        var errorPopup = document.createElement('div');
+                        errorPopup.innerHTML = 'Cannot retrieve GPS position. Signal is absent.'
+                        errorPopup.setAttribute('id', 'error-popup');
+                        document.body.appendChild(errorPopup);
+                    }
                     return;
                 }
             };
@@ -5330,10 +5376,20 @@ AFRAME.registerComponent('gps-projected-camera', {
 
                 document.addEventListener('touchend', function() { handler() }, false);
 
-                alert('After camera permission prompt, please tap the screen to activate geolocation.');
+                if (!document.getElementById('error-popup')) {
+                    var errorPopup = document.createElement('div');
+                    errorPopup.innerHTML = 'After camera permission prompt, please tap the screen to activate geolocation.'
+                    errorPopup.setAttribute('id', 'error-popup');
+                    document.body.appendChild(errorPopup);
+                }
             } else {
                 var timeout = setTimeout(function() {
-                    alert('Please enable device orientation in Settings > Safari > Motion & Orientation Access.')
+                    if (!document.getElementById('error-popup')) {
+                        var errorPopup = document.createElement('div');
+                        errorPopup.innerHTML = 'Please enable device orientation in Settings > Safari > Motion & Orientation Access.'
+                        errorPopup.setAttribute('id', 'error-popup');
+                        document.body.appendChild(errorPopup);
+                    }
                 }, 750);
                 window.addEventListener(eventName, function() {
                     clearTimeout(timeout);
@@ -5432,12 +5488,22 @@ AFRAME.registerComponent('gps-projected-camera', {
 
                 if (err.code === 1) {
                     // User denied GeoLocation, let their know that
-                    alert('Please activate Geolocation and refresh the page. If it is already active, please check permissions for this website.');
+                    if (!document.getElementById('error-popup')) {
+                        var errorPopup = document.createElement('div');
+                        errorPopup.innerHTML = 'Please activate Geolocation and refresh the page. If it is already active, please check permissions for this website.'
+                        errorPopup.setAttribute('id', 'error-popup');
+                        document.body.appendChild(errorPopup);
+                    }        
                     return;
                 }
 
                 if (err.code === 3) {
-                    alert('Cannot retrieve GPS position. Signal is absent.');
+                    if (!document.getElementById('error-popup')) {
+                        var errorPopup = document.createElement('div');
+                        errorPopup.innerHTML = 'Cannot retrieve GPS position. Signal is absent.'
+                        errorPopup.setAttribute('id', 'error-popup');
+                        document.body.appendChild(errorPopup);
+                    }
                     return;
                 }
             };

--- a/aframe/build/aframe-ar.js
+++ b/aframe/build/aframe-ar.js
@@ -3028,7 +3028,12 @@ ARjs.Source.prototype._initSourceWebcam = function (onReady, onError) {
         window.dispatchEvent(event);
 
         setTimeout(() => {
-            alert('Webcam Error\nName: ' + error.name + '\nMessage: ' + error.message)
+            if (!document.getElementById('error-popup')) {
+                var errorPopup = document.createElement('div');
+                errorPopup.innerHTML = 'Webcam Error\nName: ' + error.name + '\nMessage: ' + error.message
+                errorPopup.setAttribute('id', 'error-popup');
+                document.body.appendChild(errorPopup);
+            }
         }, 1000);
     }
 
@@ -3139,7 +3144,12 @@ ARjs.Source.prototype.toggleMobileTorch = function () {
 
     var stream = arToolkitSource.domElement.srcObject
     if (stream instanceof MediaStream === false) {
-        alert('enabling mobile torch is available only on webcam')
+        if (!document.getElementById('error-popup')) {
+            var errorPopup = document.createElement('div');
+            errorPopup.innerHTML = 'enabling mobile torch is available only on webcam'
+            errorPopup.setAttribute('id', 'error-popup');
+            document.body.appendChild(errorPopup);
+        }
         return
     }
 
@@ -3151,7 +3161,12 @@ ARjs.Source.prototype.toggleMobileTorch = function () {
     var capabilities = videoTrack.getCapabilities()
 
     if (!capabilities.torch) {
-        alert('no mobile torch is available on your camera')
+        if (!document.getElementById('error-popup')) {
+            var errorPopup = document.createElement('div');
+            errorPopup.innerHTML = 'no mobile torch is available on your camera'
+            errorPopup.setAttribute('id', 'error-popup');
+            document.body.appendChild(errorPopup);
+        }
         return
     }
 
@@ -6010,9 +6025,20 @@ AFRAME.registerComponent('arjs-webcam-texture', {
                 this.video.srcObject = stream;    
                 this.video.play();
             })
-            .catch(e => { alert(`Webcam error: ${e}`); });
+            .catch(e => {  
+                if (!document.getElementById('error-popup')) {
+                    var errorPopup = document.createElement('div');
+                    errorPopup.innerHTML = `Webcam error: ${e}`
+                    errorPopup.setAttribute('id', 'error-popup');
+                    document.body.appendChild(errorPopup);
+                } });
         } else {
-            alert('sorry - media devices API not supported');
+            if (!document.getElementById('error-popup')) {
+                var errorPopup = document.createElement('div');
+                errorPopup.innerHTML = 'sorry - media devices API not supported'
+                errorPopup.setAttribute('id', 'error-popup');
+                document.body.appendChild(errorPopup);
+            }
         }
     },
 
@@ -6135,10 +6161,20 @@ AFRAME.registerComponent('gps-camera', {
 
                 document.addEventListener('touchend', function () { handler() }, false);
 
-                alert('After camera permission prompt, please tap the screen to activate geolocation.');
+                if (!document.getElementById('error-popup')) {
+                    var errorPopup = document.createElement('div');
+                    errorPopup.innerHTML = 'After camera permission prompt, please tap the screen to activate geolocation.'
+                    errorPopup.setAttribute('id', 'error-popup');
+                    document.body.appendChild(errorPopup);
+                }    
             } else {
                 var timeout = setTimeout(function () {
-                    alert('Please enable device orientation in Settings > Safari > Motion & Orientation Access.')
+                    if (!document.getElementById('error-popup')) {
+                        var errorPopup = document.createElement('div');
+                        errorPopup.innerHTML = 'Please enable device orientation in Settings > Safari > Motion & Orientation Access.'
+                        errorPopup.setAttribute('id', 'error-popup');
+                        document.body.appendChild(errorPopup);
+                    }
                 }, 750);
                 window.addEventListener(eventName, function () {
                     clearTimeout(timeout);
@@ -6240,12 +6276,22 @@ AFRAME.registerComponent('gps-camera', {
 
                 if (err.code === 1) {
                     // User denied GeoLocation, let their know that
-                    alert('Please activate Geolocation and refresh the page. If it is already active, please check permissions for this website.');
+                    if (!document.getElementById('error-popup')) {
+                        var errorPopup = document.createElement('div');
+                        errorPopup.innerHTML = 'Please activate Geolocation and refresh the page. If it is already active, please check permissions for this website.'
+                        errorPopup.setAttribute('id', 'error-popup');
+                        document.body.appendChild(errorPopup);
+                    }
                     return;
                 }
 
                 if (err.code === 3) {
-                    alert('Cannot retrieve GPS position. Signal is absent.');
+                    if (!document.getElementById('error-popup')) {
+                        var errorPopup = document.createElement('div');
+                        errorPopup.innerHTML = 'Cannot retrieve GPS position. Signal is absent.'
+                        errorPopup.setAttribute('id', 'error-popup');
+                        document.body.appendChild(errorPopup);
+                    }
                     return;
                 }
             };
@@ -6701,10 +6747,20 @@ AFRAME.registerComponent('gps-projected-camera', {
 
                 document.addEventListener('touchend', function() { handler() }, false);
 
-                alert('After camera permission prompt, please tap the screen to activate geolocation.');
+                if (!document.getElementById('error-popup')) {
+                    var errorPopup = document.createElement('div');
+                    errorPopup.innerHTML = 'After camera permission prompt, please tap the screen to activate geolocation.'
+                    errorPopup.setAttribute('id', 'error-popup');
+                    document.body.appendChild(errorPopup);
+                }
             } else {
                 var timeout = setTimeout(function() {
-                    alert('Please enable device orientation in Settings > Safari > Motion & Orientation Access.')
+                    if (!document.getElementById('error-popup')) {
+                        var errorPopup = document.createElement('div');
+                        errorPopup.innerHTML = 'Please enable device orientation in Settings > Safari > Motion & Orientation Access.'
+                        errorPopup.setAttribute('id', 'error-popup');
+                        document.body.appendChild(errorPopup);
+                    }
                 }, 750);
                 window.addEventListener(eventName, function() {
                     clearTimeout(timeout);
@@ -6803,12 +6859,22 @@ AFRAME.registerComponent('gps-projected-camera', {
 
                 if (err.code === 1) {
                     // User denied GeoLocation, let their know that
-                    alert('Please activate Geolocation and refresh the page. If it is already active, please check permissions for this website.');
+                    if (!document.getElementById('error-popup')) {
+                        var errorPopup = document.createElement('div');
+                        errorPopup.innerHTML = 'Please activate Geolocation and refresh the page. If it is already active, please check permissions for this website.'
+                        errorPopup.setAttribute('id', 'error-popup');
+                        document.body.appendChild(errorPopup);
+                    }        
                     return;
                 }
 
                 if (err.code === 3) {
-                    alert('Cannot retrieve GPS position. Signal is absent.');
+                    if (!document.getElementById('error-popup')) {
+                        var errorPopup = document.createElement('div');
+                        errorPopup.innerHTML = 'Cannot retrieve GPS position. Signal is absent.'
+                        errorPopup.setAttribute('id', 'error-popup');
+                        document.body.appendChild(errorPopup);
+                    }
                     return;
                 }
             };

--- a/aframe/src/location-based/arjs-webcam-texture.js
+++ b/aframe/src/location-based/arjs-webcam-texture.js
@@ -27,9 +27,20 @@ AFRAME.registerComponent('arjs-webcam-texture', {
                 this.video.srcObject = stream;    
                 this.video.play();
             })
-            .catch(e => { alert(`Webcam error: ${e}`); });
+            .catch(e => {  
+                if (!document.getElementById('error-popup')) {
+                    var errorPopup = document.createElement('div');
+                    errorPopup.innerHTML = `Webcam error: ${e}`
+                    errorPopup.setAttribute('id', 'error-popup');
+                    document.body.appendChild(errorPopup);
+                } });
         } else {
-            alert('sorry - media devices API not supported');
+            if (!document.getElementById('error-popup')) {
+                var errorPopup = document.createElement('div');
+                errorPopup.innerHTML = 'sorry - media devices API not supported'
+                errorPopup.setAttribute('id', 'error-popup');
+                document.body.appendChild(errorPopup);
+            }
         }
     },
 

--- a/aframe/src/location-based/gps-camera.js
+++ b/aframe/src/location-based/gps-camera.js
@@ -99,10 +99,20 @@ AFRAME.registerComponent('gps-camera', {
 
                 document.addEventListener('touchend', function () { handler() }, false);
 
-                alert('After camera permission prompt, please tap the screen to activate geolocation.');
+                if (!document.getElementById('error-popup')) {
+                    var errorPopup = document.createElement('div');
+                    errorPopup.innerHTML = 'After camera permission prompt, please tap the screen to activate geolocation.'
+                    errorPopup.setAttribute('id', 'error-popup');
+                    document.body.appendChild(errorPopup);
+                }    
             } else {
                 var timeout = setTimeout(function () {
-                    alert('Please enable device orientation in Settings > Safari > Motion & Orientation Access.')
+                    if (!document.getElementById('error-popup')) {
+                        var errorPopup = document.createElement('div');
+                        errorPopup.innerHTML = 'Please enable device orientation in Settings > Safari > Motion & Orientation Access.'
+                        errorPopup.setAttribute('id', 'error-popup');
+                        document.body.appendChild(errorPopup);
+                    }
                 }, 750);
                 window.addEventListener(eventName, function () {
                     clearTimeout(timeout);
@@ -204,12 +214,22 @@ AFRAME.registerComponent('gps-camera', {
 
                 if (err.code === 1) {
                     // User denied GeoLocation, let their know that
-                    alert('Please activate Geolocation and refresh the page. If it is already active, please check permissions for this website.');
+                    if (!document.getElementById('error-popup')) {
+                        var errorPopup = document.createElement('div');
+                        errorPopup.innerHTML = 'Please activate Geolocation and refresh the page. If it is already active, please check permissions for this website.'
+                        errorPopup.setAttribute('id', 'error-popup');
+                        document.body.appendChild(errorPopup);
+                    }
                     return;
                 }
 
                 if (err.code === 3) {
-                    alert('Cannot retrieve GPS position. Signal is absent.');
+                    if (!document.getElementById('error-popup')) {
+                        var errorPopup = document.createElement('div');
+                        errorPopup.innerHTML = 'Cannot retrieve GPS position. Signal is absent.'
+                        errorPopup.setAttribute('id', 'error-popup');
+                        document.body.appendChild(errorPopup);
+                    }
                     return;
                 }
             };

--- a/aframe/src/location-based/gps-projected-camera.js
+++ b/aframe/src/location-based/gps-projected-camera.js
@@ -117,10 +117,20 @@ AFRAME.registerComponent('gps-projected-camera', {
 
                 document.addEventListener('touchend', function() { handler() }, false);
 
-                alert('After camera permission prompt, please tap the screen to activate geolocation.');
+                if (!document.getElementById('error-popup')) {
+                    var errorPopup = document.createElement('div');
+                    errorPopup.innerHTML = 'After camera permission prompt, please tap the screen to activate geolocation.'
+                    errorPopup.setAttribute('id', 'error-popup');
+                    document.body.appendChild(errorPopup);
+                }
             } else {
                 var timeout = setTimeout(function() {
-                    alert('Please enable device orientation in Settings > Safari > Motion & Orientation Access.')
+                    if (!document.getElementById('error-popup')) {
+                        var errorPopup = document.createElement('div');
+                        errorPopup.innerHTML = 'Please enable device orientation in Settings > Safari > Motion & Orientation Access.'
+                        errorPopup.setAttribute('id', 'error-popup');
+                        document.body.appendChild(errorPopup);
+                    }
                 }, 750);
                 window.addEventListener(eventName, function() {
                     clearTimeout(timeout);
@@ -219,12 +229,22 @@ AFRAME.registerComponent('gps-projected-camera', {
 
                 if (err.code === 1) {
                     // User denied GeoLocation, let their know that
-                    alert('Please activate Geolocation and refresh the page. If it is already active, please check permissions for this website.');
+                    if (!document.getElementById('error-popup')) {
+                        var errorPopup = document.createElement('div');
+                        errorPopup.innerHTML = 'Please activate Geolocation and refresh the page. If it is already active, please check permissions for this website.'
+                        errorPopup.setAttribute('id', 'error-popup');
+                        document.body.appendChild(errorPopup);
+                    }        
                     return;
                 }
 
                 if (err.code === 3) {
-                    alert('Cannot retrieve GPS position. Signal is absent.');
+                    if (!document.getElementById('error-popup')) {
+                        var errorPopup = document.createElement('div');
+                        errorPopup.innerHTML = 'Cannot retrieve GPS position. Signal is absent.'
+                        errorPopup.setAttribute('id', 'error-popup');
+                        document.body.appendChild(errorPopup);
+                    }
                     return;
                 }
             };

--- a/three.js/build/ar-nft.js
+++ b/three.js/build/ar-nft.js
@@ -1628,7 +1628,12 @@ ARjs.Source.prototype._initSourceWebcam = function (onReady, onError) {
         window.dispatchEvent(event);
 
         setTimeout(() => {
-            alert('Webcam Error\nName: ' + error.name + '\nMessage: ' + error.message)
+            if (!document.getElementById('error-popup')) {
+                var errorPopup = document.createElement('div');
+                errorPopup.innerHTML = 'Webcam Error\nName: ' + error.name + '\nMessage: ' + error.message
+                errorPopup.setAttribute('id', 'error-popup');
+                document.body.appendChild(errorPopup);
+            }
         }, 1000);
     }
 
@@ -1739,7 +1744,12 @@ ARjs.Source.prototype.toggleMobileTorch = function () {
 
     var stream = arToolkitSource.domElement.srcObject
     if (stream instanceof MediaStream === false) {
-        alert('enabling mobile torch is available only on webcam')
+        if (!document.getElementById('error-popup')) {
+            var errorPopup = document.createElement('div');
+            errorPopup.innerHTML = 'enabling mobile torch is available only on webcam'
+            errorPopup.setAttribute('id', 'error-popup');
+            document.body.appendChild(errorPopup);
+        }
         return
     }
 
@@ -1751,7 +1761,12 @@ ARjs.Source.prototype.toggleMobileTorch = function () {
     var capabilities = videoTrack.getCapabilities()
 
     if (!capabilities.torch) {
-        alert('no mobile torch is available on your camera')
+        if (!document.getElementById('error-popup')) {
+            var errorPopup = document.createElement('div');
+            errorPopup.innerHTML = 'no mobile torch is available on your camera'
+            errorPopup.setAttribute('id', 'error-popup');
+            document.body.appendChild(errorPopup);
+        }
         return
     }
 

--- a/three.js/build/ar.js
+++ b/three.js/build/ar.js
@@ -3028,7 +3028,12 @@ ARjs.Source.prototype._initSourceWebcam = function (onReady, onError) {
         window.dispatchEvent(event);
 
         setTimeout(() => {
-            alert('Webcam Error\nName: ' + error.name + '\nMessage: ' + error.message)
+            if (!document.getElementById('error-popup')) {
+                var errorPopup = document.createElement('div');
+                errorPopup.innerHTML = 'Webcam Error\nName: ' + error.name + '\nMessage: ' + error.message
+                errorPopup.setAttribute('id', 'error-popup');
+                document.body.appendChild(errorPopup);
+            }
         }, 1000);
     }
 
@@ -3139,7 +3144,12 @@ ARjs.Source.prototype.toggleMobileTorch = function () {
 
     var stream = arToolkitSource.domElement.srcObject
     if (stream instanceof MediaStream === false) {
-        alert('enabling mobile torch is available only on webcam')
+        if (!document.getElementById('error-popup')) {
+            var errorPopup = document.createElement('div');
+            errorPopup.innerHTML = 'enabling mobile torch is available only on webcam'
+            errorPopup.setAttribute('id', 'error-popup');
+            document.body.appendChild(errorPopup);
+        }
         return
     }
 
@@ -3151,7 +3161,12 @@ ARjs.Source.prototype.toggleMobileTorch = function () {
     var capabilities = videoTrack.getCapabilities()
 
     if (!capabilities.torch) {
-        alert('no mobile torch is available on your camera')
+        if (!document.getElementById('error-popup')) {
+            var errorPopup = document.createElement('div');
+            errorPopup.innerHTML = 'no mobile torch is available on your camera'
+            errorPopup.setAttribute('id', 'error-popup');
+            document.body.appendChild(errorPopup);
+        }
         return
     }
 

--- a/three.js/src/threex/threex-artoolkitsource.js
+++ b/three.js/src/threex/threex-artoolkitsource.js
@@ -155,7 +155,12 @@ ARjs.Source.prototype._initSourceWebcam = function (onReady, onError) {
         window.dispatchEvent(event);
 
         setTimeout(() => {
-            alert('Webcam Error\nName: ' + error.name + '\nMessage: ' + error.message)
+            if (!document.getElementById('error-popup')) {
+                var errorPopup = document.createElement('div');
+                errorPopup.innerHTML = 'Webcam Error\nName: ' + error.name + '\nMessage: ' + error.message
+                errorPopup.setAttribute('id', 'error-popup');
+                document.body.appendChild(errorPopup);
+            }
         }, 1000);
     }
 
@@ -266,7 +271,12 @@ ARjs.Source.prototype.toggleMobileTorch = function () {
 
     var stream = arToolkitSource.domElement.srcObject
     if (stream instanceof MediaStream === false) {
-        alert('enabling mobile torch is available only on webcam')
+        if (!document.getElementById('error-popup')) {
+            var errorPopup = document.createElement('div');
+            errorPopup.innerHTML = 'enabling mobile torch is available only on webcam'
+            errorPopup.setAttribute('id', 'error-popup');
+            document.body.appendChild(errorPopup);
+        }
         return
     }
 
@@ -278,7 +288,12 @@ ARjs.Source.prototype.toggleMobileTorch = function () {
     var capabilities = videoTrack.getCapabilities()
 
     if (!capabilities.torch) {
-        alert('no mobile torch is available on your camera')
+        if (!document.getElementById('error-popup')) {
+            var errorPopup = document.createElement('div');
+            errorPopup.innerHTML = 'no mobile torch is available on your camera'
+            errorPopup.setAttribute('id', 'error-popup');
+            document.body.appendChild(errorPopup);
+        }
         return
     }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- Can be a new feature, a bugfix, or refactoring, etc -->
Minor improvement on how error messages are displayed.  

**Can it be referenced to an Issue? If so what is the issue # ?**
No.

**How can we test it?**
Trigger errors/warnings and confirm HTML div with correct error message is added. 

**Summary**

Problem: 
- Error messages provided by AR.js do not have a consistent interface: some are displayed using the browser alert() function and others using HTML elements. 
- AR.js sometimes displays multiple error messages in a row (for example, when permissions to access camera and location are not provided, two error messages are displayed), which results in multiple alert dialogs to be displayed consecutively. It is known that such practice is not recommended for user experience reasons and the use of alert() should be avoided. 	
- Finally, by using the alert() function, application developers are not able to customize the design of how errors messages are displayed to suit each application needs.

Solution: 
- Errors are displayed by creating a HTML div and appending it to the document body. The div includes a Id attribute to enable manipulation of the element and styling. 
- A maximum of 1 error message is displayed to avoid providing too long/multiple error messages to users. Given that the errors require some action by the user and restarting the application, if more than 1 error is present initially, remaining errors will be displayed one at a time after restart. 

**Does this PR introduce a breaking change?**
No.
Tested on Poco X3 with Chrome 90.0.4430.91 and on Iphone Xr with iOS 13.5 and iOS 14.5. 

**Other information**
-