### PR TITLE
Update system-arjs.js

### DIFF
--- a/aframe/src/system-arjs.js
+++ b/aframe/src/system-arjs.js
@@ -213,15 +213,40 @@ AFRAME.registerSystem('arjs', {
         //////////////////////////////////////////////////////////////////////////////
         // TODO this is crappy - code an exponential backoff - max 1 seconds
         // KLUDGE: kludge to write a 'resize' event
-        var startedAt = Date.now()
-        var timerId = setInterval(function () {
-            if (Date.now() - startedAt > 10000 * 1000) {
-                clearInterval(timerId)
-                return
+        // var startedAt = Date.now()
+        // var timerId = setInterval(function () {
+        //     if (Date.now() - startedAt > 10000 * 1000) {
+        //         clearInterval(timerId)
+        //         return
+        //     }
+        //     // onResize()
+        //     window.dispatchEvent(new Event('resize'));
+        // }, 1000 / 30)
+
+        function setBackoff(func, millisDuration = Infinity, limit = 1000) {
+            if(func == null || !(Object.prototype.toString.call(func) == '[object Function]')) {
+                return;
+            } 
+            let backoff = 33.3
+            let start = Date.now()
+            let repeat = function() {
+              return (millisDuration == Infinity || (Date.now() - start) < millisDuration)
             }
-            // onResize()
-            window.dispatchEvent(new Event('resize'));
-        }, 1000 / 30)
+            let next = function() {
+                backoff = (backoff * 2) < limit ? (backoff * 2) : limit
+                setTimeout(function() {
+                    func()
+                    if(repeat()) {
+                        next()
+                    }
+                }, backoff)
+            };
+            next()
+        }
+
+        setBackoff(() => {
+            window.dispatchEvent(new Event('resize'))
+        })
     },
 
     tick: function () {


### PR DESCRIPTION
Added exponential backoff function to the Aframe build (system-arjs.js)

<!-- Please, don't delete this template or we'll close your issue -->

**⚠️ All PRs have to be done versus 'dev' branch, so be aware of that, or we'll close your issue ⚠️**

**What kind of change does this PR introduce?**
I have added a simple exponential backoff function to the Aframe build (system-arjs.js)

**Can it be referenced to an Issue? If so what is the issue # ?**
No, this PR was not made in response to an issue.

**How can we test it?**
<!-- All information can be found about our tests in https://github.com/jeromeetienne/AR.js/blob/master/test/TODO.md -->
If you build/make the Aframe version of ar.js and are able to use it, it should be working correctly. The previous build used a setInterval function to resize the ar.js document element - this setInterval function fired every 33.3 seconds, and had a maximum duration of several hours. The function I made to replace it will fire at 33.3 millis, 66.6 millis, 99.9 millis, etc --- doubling every time, until a limit is hit (by default, 1 second, as noted in the comments requesting this feature)

It also has a maximum duration setting, but by default it will run forever (duration is set to Infinity by default).

<!-- At the moment we don't explicitly require tests, because it's not streamlined yet -->

**Summary**
I saw in the comments that an exponential backoff function was intended, but not yet written - So I made one (setBackoff). I tested the build and it works (more info below). Much like setTimeout & setInterval, setBackoff takes a function and a duration. The duration is set to Infinity by default, meaning the code will continue to repeat without limit. If a duration is provided, it will be called until that duration is exceeded. The final optional parameter sets the limit or ceiling for the backoff in milliseconds. The default value is 1000 (1 second), meaning the greatest interval of the backoff will not exceed 1 second.

**Does this PR introduce a breaking change?**
No, this change requires no refactoring.

**Please TEST your PR before proposing it. Specify here what device you have used for tests, version of OS and version of Browser**

Tested on Windows 10 Home version 20H2, 64-bit operating system, x64-based processor (Browser: Firefox 89.0.2)
Tested on Pixel 2, Android 11 (Browser: Chrome 91.0.4472.120)


**Other information**
N/A
