### PR TITLE
Fix generator marker info dialog in Firefox, and point to working documentation

### DIFF
--- a/three.js/examples/marker-training/examples/generator.html
+++ b/three.js/examples/marker-training/examples/generator.html
@@ -4,6 +4,7 @@
 <link rel='stylesheet' href='https://fonts.googleapis.com/icon?family=Material+Icons'>
 <link rel='stylesheet' href='https://code.getmdl.io/1.3.0/material.indigo-pink.min.css'>
 <script defer src='https://code.getmdl.io/1.3.0/material.min.js'></script>
+<script src='https://unpkg.com/dialog-polyfill@0.5.6/dist/dialog-polyfill.js'></script>
 <link href='https://fonts.googleapis.com/icon?family=Material+Icons' rel='stylesheet'>
 
 <!-- Include pdfMake - http://pdfmake.org/ -->
@@ -61,7 +62,7 @@
 <dialog style='width:400px' id='dialog-info' class="mdl-dialog">
 	<h4 class="mdl-dialog__title">Welcome!</h4>
 	<div class="mdl-dialog__content">
-		Details on how to pick the inner image can be found <a target='_blank' href='https://artoolkit.org/documentation/doku.php?id=3_Marker_Training:marker_training'>here</a>
+		Details on how to pick the inner image can be found <a target='_blank' href='https://kalwalt.github.io/artoolkit-docs/3_Marker_Training/marker_training.html'>here</a>
 	</div>
 	<div class="mdl-dialog__actions">
 		<button type="button" class="mdl-button">OK</button>
@@ -70,7 +71,7 @@
 <script>
 	var dialogElement = document.querySelector('#dialog-info')
 	if (! dialogElement.showModal) {
-		dialogElementPolyfill.registerDialog(dialogElement)
+		dialogPolyfill.registerDialog(dialogElement)
 	}
 	dialogElement.querySelector('.mdl-dialog__actions button').addEventListener('click', function() {
 		dialogElement.close()


### PR DESCRIPTION
<!-- Please, don't delete this template or we'll close your issue -->

**What kind of change does this PR introduce?**
The info dialog was broken in Firefox because of a missing polyfill. I also changed the artoolkit documentation link since the documentation at artoolkit.org [isn't working correctly](https://github.com/artoolkit/ARToolKit5/issues/4). I believe the [new link](https://kalwalt.github.io/artoolkit-docs/3_Marker_Training/marker_about.html) is an equivalent copy of the documentation.

**How can we test it?**
You can test the fixed version here: https://raw.githack.com/brianpeiris/AR.js/fix-info-dialog/three.js/examples/marker-training/examples/generator.html

**Does this PR introduce a breaking change?**
Nope

**Please TEST your PR before proposing it. Specify here what device you have used for tests, version of OS and version of Browser**
Tested in Firefox and Chrome on Windows.