### PR TITLE
Replaced alert method for webcam errors

### DIFF
--- a/three.js/src/location-based/js/webcam-renderer.js
+++ b/three.js/src/location-based/js/webcam-renderer.js
@@ -44,10 +44,26 @@ class WebcamRenderer {
           video.play();
         })
         .catch((e) => {
-          alert(`Webcam error: ${e}`);
+          setTimeout(() => {
+            if (!document.getElementById("error-popup")) {
+              var errorPopup = document.createElement("div");
+              errorPopup.innerHTML =
+                "Webcam Error\nName: " + e.name + "\nMessage: " + e.message;
+              errorPopup.setAttribute("id", "error-popup");
+              document.body.appendChild(errorPopup);
+            }
+          }, 1000);
         });
     } else {
-      alert("sorry - media devices API not supported");
+      setTimeout(() => {
+        if (!document.getElementById("error-popup")) {
+          var errorPopup = document.createElement("div");
+          errorPopup.innerHTML =
+            "sorry - media devices API not supported";
+          errorPopup.setAttribute("id", "error-popup");
+          document.body.appendChild(errorPopup);
+        }
+      }, 1000);
     }
   }
 


### PR DESCRIPTION
Adjusted webcam error reporting to insert a DOM object instead of native alert method

<!-- Please, don't delete this template or we'll close your issue -->

**⚠️ All PRs have to be done versus 'dev' branch, so be aware of that, or we'll close your issue ⚠️**

**What kind of change does this PR introduce?**
<!-- Can be a new feature, a bugfix, or refactoring, etc -->

Improvement

**Can it be referenced to an Issue? If so what is the issue # ?**

**How can we test it?**
<!-- All information can be found about our tests in https://github.com/jeromeetienne/AR.js/blob/master/test/TODO.md -->
<!-- At the moment we don't explicitly require tests, because it's not streamlined yet -->

Run an AR.js project and reject giving the permission to use the camera. No alert() box should be shown.

**Summary**
<!-- State here what problem the PR solves and what is the proposed solution -->
The usage of the native alert() function does not allow to control the UX flow nor the look and feel of the error message. With the change, a DOM element is attached to the document, containing the error.

**Does this PR introduce a breaking change?**
The side-effect of appending a DOM element could be unwanted. However, [three.js/src/threex/arjs-source.js](https://github.com/AR-js-org/AR.js/blob/3fdc52a2fcd7665f6329324e19a5bc6ffd99aab5/three.js/src/threex/arjs-source.js) also adds such a DOM element with id #error-popup and, therefore, clients should have designed for it already.

**Please TEST your PR before proposing it. Specify here what device you have used for tests, version of OS and version of Browser**

**Other information**
