### PR TITLE
Fix scope undef this.orientationChangeEventName

### DIFF
--- a/three.js/src/location-based/js/device-orientation-controls.js
+++ b/three.js/src/location-based/js/device-orientation-controls.js
@@ -89,7 +89,7 @@ class DeviceOrientationControls extends EventDispatcher {
                 onScreenOrientationChangeEvent
               );
               window.addEventListener(
-                this.orientationChangeEventName,
+                scope.orientationChangeEventName,
                 onDeviceOrientationChangeEvent
               );
             }
@@ -106,7 +106,7 @@ class DeviceOrientationControls extends EventDispatcher {
           onScreenOrientationChangeEvent
         );
         window.addEventListener(
-          this.orientationChangeEventName,
+          scope.orientationChangeEventName,
           onDeviceOrientationChangeEvent
         );
       }
@@ -120,7 +120,7 @@ class DeviceOrientationControls extends EventDispatcher {
         onScreenOrientationChangeEvent
       );
       window.removeEventListener(
-        this.orientationChangeEventName,
+        scope.orientationChangeEventName,
         onDeviceOrientationChangeEvent
       );
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
**Bugfix**

**Can it be referenced to an Issue? If so what is the issue # ?**

- [X] Will do
https://github.com/AR-js-org/AR.js/issues/465

**How can we test it?**

Use DeviceOrientationControls using `ar-threex-location-only.js` and possibly `aframe-ar-location-only.js` (+ others?), and there will not be an `this.orientationChangeEventName undefined` error.

```javascript
...
const camera = new THREE.PerspectiveCamera(80, 2, 0.1, 50000);
const deviceOrientationControls = new THREEx.DeviceOrientationControls(camera);
....
```

**Summary**
This PR sets the correct scope:
`this.orientationChangeEventName` -> `scope.orientationChangeEventName`/`t.orientationChangeEventName`

**Does this PR introduce a breaking change?**

- [x] No


**Other information**

Tested physical device iOS 16 within a cordova app. 
However this (simple fix) and bug will impact all iDevices.

It seems a similar fix was merged earlier https://github.com/AR-js-org/AR.js/pull/432.
There it was solved with an arrow function.

However I do feel that mixing `scope` and `this` when `const scope = this;` allows for the kind of bug to be introduced as it currently exists in the master.  It might have less fancy points but it might get some consistency/style points.