### PR TITLE
Fix WebKit/iOS13+ initial heading/alpha correction

### DIFF
--- a/aframe/src/location-based/ArjsDeviceOrientationControls.js
+++ b/aframe/src/location-based/ArjsDeviceOrientationControls.js
@@ -98,11 +98,18 @@ const ArjsDeviceOrientationControls = function (object) {
 
     var device = scope.deviceOrientation;
 
-    if (device) {
-      var alpha = device.alpha
-        ? THREE.Math.degToRad(device.alpha) + scope.alphaOffset
-        : 0; // Z
+    if (device) {      
+      // iOS compass-calibrated 'alpha' patch
+      // see: http://lists.w3.org/Archives/Public/public-geolocation/2011Jul/0014.html
+      var heading = device.webkitCompassHeading || device.compassHeading;
 
+      var alpha = device.alpha || heading
+          ? MathUtils.degToRad(
+              heading
+              ? 360 - heading
+              : device.alpha || 0) + scope.alphaOffset
+          : 0; // Z
+      
       var beta = device.beta ? THREE.Math.degToRad(device.beta) : 0; // X'
 
       var gamma = device.gamma ? THREE.Math.degToRad(device.gamma) : 0; // Y''

--- a/three.js/src/location-based/js/device-orientation-controls.js
+++ b/three.js/src/location-based/js/device-orientation-controls.js
@@ -133,8 +133,15 @@ class DeviceOrientationControls extends EventDispatcher {
       const device = scope.deviceOrientation;
 
       if (device) {
-        const alpha = device.alpha
-          ? MathUtils.degToRad(device.alpha) + scope.alphaOffset
+        // iOS compass-calibrated 'alpha' patch
+        // see: http://lists.w3.org/Archives/Public/public-geolocation/2011Jul/0014.html
+        const heading = device.webkitCompassHeading || device.compassHeading;
+        
+        const alpha = device.alpha || heading
+          ? MathUtils.degToRad(
+              heading  
+              ? 360 - heading
+              : device.alpha || 0) + scope.alphaOffset
           : 0; // Z
 
         const beta = device.beta ? MathUtils.degToRad(device.beta) : 0; // X'


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Re-intruduce WebKit/iOS 13+ support for deviceControls

**Can it be referenced to an Issue? If so what is the issue # ?**
- [X] Done
https://github.com/AR-js-org/AR.js/issues/466

**How can we test it?**
Borrow/steal a iDevice with iOS13 + 

**Summary**
Without this PR and on iOS the 'north'/alpha is set to whatever direction you happen face when initialising the controls.

**Does this PR introduce a breaking change?**
- [X] No

**Please TEST your PR before proposing it. Specify here what device you have used for tests, version of OS and version of Browser**
- [X] iOS 16 iPhone 12 Mini - Physical 
- [X] iOS 14.8.1 iPhone SE (1st gen) - Physical

**Other information**
Probably merge https://github.com/AR-js-org/AR.js/pull/464 first, before testing as the `onDeviceOrientationChangeEvent` does not function without it anyway.