### PR TITLE
fix:  THREE.Math does not exist

### DIFF
--- a/three.js/src/location-based/js/device-orientation-controls.js
+++ b/three.js/src/location-based/js/device-orientation-controls.js
@@ -1,13 +1,7 @@
 // Modified version of THREE.DeviceOrientationControls from three.js
 // will use the deviceorientationabsolute event if available
 
-import {
-  Euler,
-  EventDispatcher,
-  Math as MathUtils,
-  Quaternion,
-  Vector3,
-} from "three";
+import { Euler, EventDispatcher, MathUtils, Quaternion, Vector3 } from "three";
 
 const _zee = new Vector3(0, 0, 1);
 const _euler = new Euler();

--- a/three.js/src/location-based/js/webcam-renderer.js
+++ b/three.js/src/location-based/js/webcam-renderer.js
@@ -15,7 +15,7 @@ class WebcamRenderer {
     } else {
       video = document.querySelector(videoElement);
     }
-    this.geom = new THREE.PlaneBufferGeometry();
+    this.geom = new THREE.PlaneGeometry();
     this.texture = new THREE.VideoTexture(video);
     this.material = new THREE.MeshBasicMaterial({ map: this.texture });
     const mesh = new THREE.Mesh(this.geom, this.material);


### PR DESCRIPTION
THREE.Math was renamed to THREE.MathUtils in r113. THREE.PlaneBufferGeometry is deprecated.

Fixes #515

<!-- Please, don't delete this template or we'll close your issue -->

**⚠️ All PRs have to be done versus 'dev' branch, so be aware of that, or we'll close your issue ⚠️**

**What kind of change does this PR introduce?**  bugfix
<!-- Can be a new feature, a bugfix, or refactoring, etc -->

**Can it be referenced to an Issue? If so what is the issue # ?** 515

**How can we test it?** Follow the Three.js tutorial
<!-- All information can be found about our tests in https://github.com/jeromeetienne/AR.js/blob/master/test/TODO.md -->
<!-- At the moment we don't explicitly require tests, because it's not streamlined yet -->

**Summary**
<!-- State here what problem the PR solves and what is the proposed solution -->

**Does this PR introduce a breaking change?** Potentially for folks using Three.js older than v0.113.0?

**Please TEST your PR before proposing it. Specify here what device you have used for tests, version of OS and version of Browser** Edge 110.0.1587.41 (on Android)

**Other information**
